### PR TITLE
fix: corrigir lógica de animação que impedia o modal de funcionar

### DIFF
--- a/frontend/src/components/list/LuckySpinModal.tsx
+++ b/frontend/src/components/list/LuckySpinModal.tsx
@@ -116,21 +116,21 @@ export function LuckySpinModal({ open, onOpenChange, items }: LuckySpinModalProp
       const elapsed = performance.now() - startTime
       const progress = Math.min(elapsed / totalDuration, 1)
 
-      // Quadratic easing out
-      const easedProgress = 1 - Math.pow(1 - progress, 2)
-      const targetIndex = Math.floor(easedProgress * winnerPosition)
-
-      if (targetIndex > currentIndex && currentIndex < winnerPosition) {
-        currentIndex = targetIndex
-        setCurrentDisplayIndex(currentIndex)
-      }
-
-      if (currentIndex >= winnerPosition || progress >= 1) {
-        // Reached the winner - stop
+      if (progress >= 1) {
+        // Animation complete - show winner
         setCurrentDisplayIndex(winnerPosition)
         setSelectedMovie(winner)
         setIsSpinning(false)
         return
+      }
+
+      // Quadratic easing out
+      const easedProgress = 1 - Math.pow(1 - progress, 2)
+      const targetIndex = Math.min(Math.floor(easedProgress * winnerPosition), winnerPosition)
+
+      if (targetIndex !== currentIndex) {
+        currentIndex = targetIndex
+        setCurrentDisplayIndex(currentIndex)
       }
 
       animationRef.current = window.requestAnimationFrame(animateNames)


### PR DESCRIPTION
A condição `targetIndex > currentIndex` estava impedindo a animação de iniciar, pois no início ambos eram 0. Isso causava o modal ficar travado e nunca completar.

Mudanças:
- Simplificada lógica de animação usando `targetIndex !== currentIndex`
- Movida verificação de conclusão para o topo para melhor clareza
- Adicionado Math.min para garantir que targetIndex não exceda winnerPosition
- Animação agora avança corretamente desde o frame inicial

Resultado: O modal agora funciona e completa a animação em ~3 segundos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Lucky Spin modal animation to properly stop and display the correct winner when the spin completes.
  * Eliminated animation overshooting behavior to ensure the winning item is accurately highlighted and displayed.
  * Improved animation completion logic for more consistent and reliable spinning behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->