### PR TITLE
Fix star rating click detection collision issue

### DIFF
--- a/frontend/src/components/movie/StarRating.tsx
+++ b/frontend/src/components/movie/StarRating.tsx
@@ -12,7 +12,7 @@ interface StarRatingProps {
 }
 
 export function StarRating({ rating, onChange, readonly = false, size = 'md', disabled = false, className }: StarRatingProps) {
-  const containerRef = useRef<HTMLDivElement>(null)
+  const starsRef = useRef<HTMLDivElement>(null)
 
   const fullCount = Math.floor(rating / 2)
   const hasHalf = rating % 2 === 1
@@ -24,67 +24,84 @@ export function StarRating({ rating, onChange, readonly = false, size = 'md', di
   }
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (readonly || disabled || !onChange || !containerRef.current) return
+    if (readonly || disabled || !onChange || !starsRef.current) return
 
-    const rect = containerRef.current.getBoundingClientRect()
-    let ratio = (e.clientX - rect.left) / rect.width
-    if (ratio < 0) ratio = 0
-    if (ratio > 1) ratio = 1
-    let value = Math.round(ratio * 10)
+    const rect = starsRef.current.getBoundingClientRect()
+    const clickX = e.clientX - rect.left
+
+    // Calculate which half-star was clicked (0-9 index)
+    // Each star is 1/5th of the width, divided into 2 halves
+    const starIndex = Math.floor((clickX / rect.width) * 5)
+    const starX = (clickX / rect.width) * 5 - starIndex
+
+    // Determine if left half (0.5) or right half (1.0) was clicked
+    const halfStar = starX < 0.5 ? 0.5 : 1.0
+
+    // Convert to rating (1-10 scale)
+    let value = Math.ceil((starIndex + halfStar) * 2)
+
+    // Clamp to valid range
     if (value < 1) value = 1
     if (value > 10) value = 10
+
     onChange(value)
   }
 
   return (
     <div
-      ref={containerRef}
-      onClick={handleClick}
       className={cn(
-        'flex gap-0.5',
-        !readonly && !disabled && 'cursor-pointer select-none group',
-        disabled && 'opacity-50 cursor-not-allowed',
+        'flex items-center gap-1.5',
         className
       )}
-      title={readonly ? undefined : 'Clique para avaliar'}
     >
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="relative transition-transform group-hover:scale-110">
-          {/* Empty star (background) */}
-          <Star
-            className={cn(
-              sizeClasses[size],
-              'text-neutral-800 fill-neutral-800 transition-colors'
-            )}
-          />
-
-          {/* Full star */}
-          {i < fullCount && (
+      <div
+        ref={starsRef}
+        onClick={handleClick}
+        className={cn(
+          'flex gap-0.5',
+          !readonly && !disabled && 'cursor-pointer select-none group',
+          disabled && 'opacity-50 cursor-not-allowed'
+        )}
+        title={readonly ? undefined : 'Clique para avaliar'}
+      >
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="relative transition-transform group-hover:scale-110">
+            {/* Empty star (background) */}
             <Star
               className={cn(
                 sizeClasses[size],
-                'absolute inset-0 text-amber-400 fill-amber-400 drop-shadow-[0_0_8px_rgba(251,191,36,0.5)]'
+                'text-neutral-800 fill-neutral-800 transition-colors'
               )}
             />
-          )}
 
-          {/* Half star */}
-          {i === fullCount && hasHalf && (
-            <div className="absolute inset-0 overflow-hidden" style={{ width: '50%' }}>
+            {/* Full star */}
+            {i < fullCount && (
               <Star
                 className={cn(
                   sizeClasses[size],
-                  'text-amber-400 fill-amber-400 drop-shadow-[0_0_8px_rgba(251,191,36,0.5)]'
+                  'absolute inset-0 text-amber-400 fill-amber-400 drop-shadow-[0_0_8px_rgba(251,191,36,0.5)]'
                 )}
               />
-            </div>
-          )}
-        </div>
-      ))}
+            )}
+
+            {/* Half star */}
+            {i === fullCount && hasHalf && (
+              <div className="absolute inset-0 overflow-hidden" style={{ width: '50%' }}>
+                <Star
+                  className={cn(
+                    sizeClasses[size],
+                    'text-amber-400 fill-amber-400 drop-shadow-[0_0_8px_rgba(251,191,36,0.5)]'
+                  )}
+                />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
 
       {rating > 0 && (
         <span className={cn(
-          'ml-1.5 font-semibold',
+          'font-semibold',
           size === 'sm' && 'text-xs',
           size === 'md' && 'text-sm',
           size === 'lg' && 'text-base',


### PR DESCRIPTION
The star rating was incorrectly calculating click positions because it
included the rating number and gaps in the hitbox calculation. This
caused clicks on 3.5 stars to register as 2 stars.

Changes:
- Separated stars container from rating display for isolated click detection
- Improved click calculation to map directly to star positions
- Click hitboxes now align precisely with visual appearance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved star rating click precision with more accurate half and whole-star value calculation on the 1-10 scale.
  * Enhanced star rating interaction with updated click handler placement for better accuracy.
  * Refined visual styling for empty stars in the rating display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->