### PR TITLE
Support zero rating (0) in backend

Updated backend to allow rating of 0 which represents "no rating":
- Modified database constraint to accept ratings between 0 and 10
- Updated controller validation to accept 0 as valid rating value
- This allows users to clear their rating or skip rating entirely

### DIFF
--- a/backend/controllers/list_controller.go
+++ b/backend/controllers/list_controller.go
@@ -679,8 +679,8 @@ func (c *ListController) updateMovie(ctx *gin.Context) {
 
 	// Validate rating if provided
 	if ratingProvided && req.Rating != nil {
-		if *req.Rating < 1 || *req.Rating > 10 {
-			respondValidationError(ctx, []string{"Rating deve estar entre 1 e 10"})
+		if *req.Rating < 0 || *req.Rating > 10 {
+			respondValidationError(ctx, []string{"Rating deve estar entre 0 e 10"})
 			return
 		}
 	}

--- a/backend/models/list_movie_user_data.go
+++ b/backend/models/list_movie_user_data.go
@@ -7,7 +7,7 @@ type ListMovieUserData struct {
 	ListID    int64     `gorm:"not null;column:list_id;index:idx_list_movie_user,unique" json:"list_id"`
 	MovieID   int64     `gorm:"not null;column:movie_id;index:idx_list_movie_user,unique" json:"movie_id"`
 	UserID    int64     `gorm:"not null;column:user_id;index:idx_list_movie_user,unique" json:"user_id"`
-	Rating    *int      `gorm:"column:rating;check:rating BETWEEN 1 AND 10" json:"rating"`
+	Rating    *int      `gorm:"column:rating;check:rating BETWEEN 0 AND 10" json:"rating"`
 	Notes     *string   `gorm:"type:text;column:notes" json:"notes"`
 	CreatedAt time.Time `gorm:"autoCreateTime;column:created_at" json:"created_at"`
 	UpdatedAt time.Time `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Movie ratings now accept 0 as a valid minimum value. The rating range has been updated from 1–10 to 0–10 across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->