### PR TITLE
Fix DAO layer validation to accept zero rating

The DAO layer had a hidden validation that was rejecting rating = 0,
even after updating the controller and model. This was the root cause
of the "Failed to update movie status" error.

Changed validation from "between 1 and 10" to "between 0 and 10" in
the UpsertMovieUserData method.

This completes the zero rating feature implementation across all layers:
- Frontend: StarRating component
- Controller: Request validation
- DAO: Data access validation (this fix)
- Model: Database constraint
- Migration: Constraint update

### DIFF
--- a/backend/daos/list_dao.go
+++ b/backend/daos/list_dao.go
@@ -310,8 +310,8 @@ func (d *movieListDAO) UpsertMovieUserData(listID, movieID, userID int64, rating
 	if ratingProvided {
 		if rating != nil {
 			r := *rating
-			if r < 1 || r > 10 {
-				return nil, errors.New("rating must be between 1 and 10")
+			if r < 0 || r > 10 {
+				return nil, errors.New("rating must be between 0 and 10")
 			}
 			cleanRating = &r
 		} else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated movie rating validation to allow ratings from 0 to 10. Users can now assign a zero rating to movies when desired, previously the minimum allowed rating was 1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->