### PR TITLE
Simplify zero rating: send null to delete rating instead of storing 0

Changed approach from storing rating=0 in database to deleting the rating entry.

Backend changes (reverted to 1-10 validation):
- models/list_movie_user_data.go: Reverted constraint to BETWEEN 1 AND 10
- controllers/list_controller.go: Reverted validation to < 1
- daos/list_dao.go: Reverted validation to < 1
- config/db.go: Removed updateRatingConstraint() migration function

Frontend changes:
- pages/List.tsx: Map rating=0 to null before sending to API
- When user clicks beginning of stars (sets rating to 0), frontend sends null
- Backend's existing logic deletes entry when rating is null (line 347-351 in DAO)

Benefits:
- Much simpler: no backend validation changes needed
- Aligns with existing architecture (DAO already handles null by deleting)
- Cleaner data model: NULL = no rating (semantically correct)
- Less code, less complexity

User experience unchanged: clicking at start of stars still clears rating.

### DIFF
--- a/backend/config/db.go
+++ b/backend/config/db.go
@@ -52,10 +52,6 @@ func connectDatabase() *gorm.DB {
 		fmt.Println("Warning: failed to backfill legacy list movie user data:", err)
 	}
 
-	if err := updateRatingConstraint(db); err != nil {
-		fmt.Println("Warning: failed to update rating constraint:", err)
-	}
-
 	fmt.Println("Database migration completed successfully")
 
 	return db
@@ -151,61 +147,6 @@ func backfillLegacyListMovieUserData(db *gorm.DB) error {
 		}
 	}
 
-	return nil
-}
-
-func updateRatingConstraint(db *gorm.DB) error {
-	// Check if the old constraint exists
-	var constraintExists bool
-	checkQuery := `
-		SELECT COUNT(*) > 0
-		FROM information_schema.TABLE_CONSTRAINTS tc
-		JOIN information_schema.CHECK_CONSTRAINTS cc ON tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
-		WHERE tc.TABLE_SCHEMA = DATABASE()
-		AND tc.TABLE_NAME = 'list_movie_user_data'
-		AND cc.CHECK_CLAUSE LIKE '%BETWEEN 1 AND 10%'
-	`
-	if err := db.Raw(checkQuery).Scan(&constraintExists).Error; err != nil {
-		return fmt.Errorf("failed to check constraint: %w", err)
-	}
-
-	if !constraintExists {
-		// Constraint already updated or doesn't exist
-		return nil
-	}
-
-	// Get the constraint name
-	var constraintName string
-	getNameQuery := `
-		SELECT tc.CONSTRAINT_NAME
-		FROM information_schema.TABLE_CONSTRAINTS tc
-		JOIN information_schema.CHECK_CONSTRAINTS cc ON tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
-		WHERE tc.TABLE_SCHEMA = DATABASE()
-		AND tc.TABLE_NAME = 'list_movie_user_data'
-		AND cc.CHECK_CLAUSE LIKE '%BETWEEN 1 AND 10%'
-		LIMIT 1
-	`
-	if err := db.Raw(getNameQuery).Scan(&constraintName).Error; err != nil {
-		return fmt.Errorf("failed to get constraint name: %w", err)
-	}
-
-	if constraintName == "" {
-		return nil
-	}
-
-	// Drop the old constraint
-	dropQuery := fmt.Sprintf("ALTER TABLE list_movie_user_data DROP CHECK %s", constraintName)
-	if err := db.Exec(dropQuery).Error; err != nil {
-		return fmt.Errorf("failed to drop old constraint: %w", err)
-	}
-
-	// Add the new constraint
-	addQuery := "ALTER TABLE list_movie_user_data ADD CONSTRAINT list_movie_user_data_chk_rating CHECK (rating BETWEEN 0 AND 10)"
-	if err := db.Exec(addQuery).Error; err != nil {
-		return fmt.Errorf("failed to add new constraint: %w", err)
-	}
-
-	fmt.Println("Successfully updated rating constraint to allow 0-10 range")
 	return nil
 }
 

--- a/backend/controllers/list_controller.go
+++ b/backend/controllers/list_controller.go
@@ -679,8 +679,8 @@ func (c *ListController) updateMovie(ctx *gin.Context) {
 
 	// Validate rating if provided
 	if ratingProvided && req.Rating != nil {
-		if *req.Rating < 0 || *req.Rating > 10 {
-			respondValidationError(ctx, []string{"Rating deve estar entre 0 e 10"})
+		if *req.Rating < 1 || *req.Rating > 10 {
+			respondValidationError(ctx, []string{"Rating deve estar entre 1 e 10"})
 			return
 		}
 	}

--- a/backend/daos/list_dao.go
+++ b/backend/daos/list_dao.go
@@ -310,8 +310,8 @@ func (d *movieListDAO) UpsertMovieUserData(listID, movieID, userID int64, rating
 	if ratingProvided {
 		if rating != nil {
 			r := *rating
-			if r < 0 || r > 10 {
-				return nil, errors.New("rating must be between 0 and 10")
+			if r < 1 || r > 10 {
+				return nil, errors.New("rating must be between 1 and 10")
 			}
 			cleanRating = &r
 		} else {

--- a/backend/models/list_movie_user_data.go
+++ b/backend/models/list_movie_user_data.go
@@ -7,7 +7,7 @@ type ListMovieUserData struct {
 	ListID    int64     `gorm:"not null;column:list_id;index:idx_list_movie_user,unique" json:"list_id"`
 	MovieID   int64     `gorm:"not null;column:movie_id;index:idx_list_movie_user,unique" json:"movie_id"`
 	UserID    int64     `gorm:"not null;column:user_id;index:idx_list_movie_user,unique" json:"user_id"`
-	Rating    *int      `gorm:"column:rating;check:rating BETWEEN 0 AND 10" json:"rating"`
+	Rating    *int      `gorm:"column:rating;check:rating BETWEEN 1 AND 10" json:"rating"`
 	Notes     *string   `gorm:"type:text;column:notes" json:"notes"`
 	CreatedAt time.Time `gorm:"autoCreateTime;column:created_at" json:"created_at"`
 	UpdatedAt time.Time `gorm:"autoUpdateTime;column:updated_at" json:"updated_at"`

--- a/frontend/src/pages/List.tsx
+++ b/frontend/src/pages/List.tsx
@@ -144,6 +144,9 @@ export default function ListPage() {
     setUpdatingRatingId(movieId)
     const previousItems = items
 
+    // Convert 0 to null (delete rating)
+    const ratingValue = value === 0 ? null : value
+
     try {
       // Optimistic update
       setItems((prev) =>
@@ -158,13 +161,13 @@ export default function ListPage() {
           }
           return {
             ...it,
-            rating: value,
-            your_entry: { ...yourEntry, rating: value },
+            rating: ratingValue,
+            your_entry: { ...yourEntry, rating: ratingValue },
           }
         })
       )
 
-      await updateListMovie(parsedId, movieId, { rating: value })
+      await updateListMovie(parsedId, movieId, { rating: ratingValue })
       const res = await getListMovies(parsedId)
       applyItems(res)
     } catch (err) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated movie rating validation to enforce a minimum rating of 1 instead of 0. Setting a rating to 0 now clears the rating entry, providing better control over rating management.

* **Chores**
  * Removed legacy database constraint management logic from initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->