### PR TITLE
Add prompt to mark movie as watched when rating is added

### DIFF
--- a/frontend/src/pages/List.tsx
+++ b/frontend/src/pages/List.tsx
@@ -167,6 +167,17 @@ export default function ListPage() {
       await updateListMovie(parsedId, movieId, { rating: value })
       const res = await getListMovies(parsedId)
       applyItems(res)
+
+      // Após adicionar nota, perguntar se quer marcar como assistido
+      const currentItem = res.find(item => item.movie_id === movieId)
+      if (currentItem && currentItem.status !== 'watched') {
+        const shouldMarkWatched = window.confirm(
+          'Deseja marcar este filme como assistido?'
+        )
+        if (shouldMarkWatched) {
+          await handleChangeStatus(movieId, 'watched')
+        }
+      }
     } catch (err) {
       setItems(previousItems)
       const message = (err as any)?.payload?.error || (err as Error).message


### PR DESCRIPTION
When a user adds a rating to a movie, a confirmation dialog now appears
asking if they want to mark the movie as watched. This only appears if
the movie's current status is not already 'watched'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation prompt after rating items; if the item is not marked as watched, users are prompted to mark it as watched with a single action.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->