### PR TITLE
Replace window.confirm with Sonner toast for watched prompt

- Install sonner library for modern toast notifications
- Add Toaster component to App.tsx with dark theme styling
- Replace window.confirm with interactive toast in List.tsx
- Toast appears in top-right corner with action buttons
- Auto-dismisses after 5 seconds if no action taken
- More modern and less intrusive user experience

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "react-dom": "^19.1.0",
         "react-i18next": "^15.4.1",
         "react-router-dom": "^7.8.2",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -4780,6 +4781,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^19.1.0",
     "react-i18next": "^15.4.1",
     "react-router-dom": "^7.8.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route } from 'react-router-dom'
+import { Toaster } from 'sonner'
 import LandingPage from './pages/LandingPage'
 import LoginPage from './pages/Login'
 import RegistroPage from './pages/Registro'
@@ -9,14 +10,28 @@ import './App.css'
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/" element={<LandingPage />} />
-      <Route path="/home" element={<HomePage />} />
-      <Route path="/list/:listId" element={<ListPage />} />
-      <Route path="/login" element={<LoginPage />} />
-      <Route path="/registro" element={<RegistroPage />} />
-      <Route path="/settings" element={<SettingsPage />} />
-    </Routes>
+    <>
+      <Toaster
+        position="top-right"
+        richColors
+        closeButton
+        toastOptions={{
+          style: {
+            background: '#171717',
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+            color: '#fff',
+          },
+        }}
+      />
+      <Routes>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/home" element={<HomePage />} />
+        <Route path="/list/:listId" element={<ListPage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/registro" element={<RegistroPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
+      </Routes>
+    </>
   )
 }
 

--- a/frontend/src/pages/List.tsx
+++ b/frontend/src/pages/List.tsx
@@ -182,6 +182,7 @@ export default function ListPage() {
           },
           cancel: {
             label: 'Não',
+            onClick: () => {}, // Apenas fecha o toast
           },
           duration: 5000,
         })

--- a/frontend/src/pages/List.tsx
+++ b/frontend/src/pages/List.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { toast } from 'sonner'
 import Header from '@/components/Header'
 import { MovieCard } from '@/components/movie/MovieCard'
 import { MovieOverlay } from '@/components/movie/MovieOverlay'
@@ -171,12 +172,19 @@ export default function ListPage() {
       // Após adicionar nota, perguntar se quer marcar como assistido
       const currentItem = res.find(item => item.movie_id === movieId)
       if (currentItem && currentItem.status !== 'watched') {
-        const shouldMarkWatched = window.confirm(
-          'Deseja marcar este filme como assistido?'
-        )
-        if (shouldMarkWatched) {
-          await handleChangeStatus(movieId, 'watched')
-        }
+        toast('🎬 Filme avaliado!', {
+          description: 'Deseja marcar este filme como assistido?',
+          action: {
+            label: '✓ Sim, marcar',
+            onClick: async () => {
+              await handleChangeStatus(movieId, 'watched')
+            },
+          },
+          cancel: {
+            label: 'Não',
+          },
+          duration: 5000,
+        })
       }
     } catch (err) {
       setItems(previousItems)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toast notifications added across the app, shown top-right with rich styling.
  * Rating a movie now triggers a toast offering to mark it as watched (with confirm/cancel options and auto-dismiss).

* **Chores**
  * Added a toast notification library dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->