### PR TITLE
Fix: Prevent movie overlay from opening when clicking stars

### DIFF
--- a/frontend/src/components/movie/StarRating.tsx
+++ b/frontend/src/components/movie/StarRating.tsx
@@ -24,6 +24,9 @@ export function StarRating({ rating, onChange, readonly = false, size = 'md', di
   }
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    // Stop event from bubbling up to parent elements (like MovieCard)
+    e.stopPropagation()
+
     if (readonly || disabled || !onChange || !starsRef.current) return
 
     const rect = starsRef.current.getBoundingClientRect()


### PR DESCRIPTION
## Summary
- Fixed issue where clicking star ratings would unintentionally open the movie details overlay
- Added `stopPropagation()` to star rating click handler to prevent event bubbling to parent MovieCard

## Test plan
- [ ] Click on stars to rate a movie and verify the overlay does not open
- [ ] Verify rating is still saved correctly
- [ ] Click on other areas of the movie card and verify overlay opens as expected

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where star rating interactions inadvertently triggered actions on parent elements, ensuring ratings function independently.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->