### PR TITLE
refactor: move ratings section to overlay and add stats indicators

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -176,6 +176,30 @@
     "watching": "Watching",
     "watched": "Watched",
     "dropped": "Dropped"
+  },
+  "movieCard": {
+    "ratings_one": "rating",
+    "ratings_other": "ratings",
+    "comments_one": "comment",
+    "comments_other": "comments",
+    "remove": "Remove",
+    "saving": "Saving…",
+    "removing": "Removing…",
+    "mediaType": {
+      "movie": "Movie",
+      "tv": "Series"
+    }
+  },
+  "movieOverlay": {
+    "yourRating": "Your rating:",
+    "synopsis": "Synopsis",
+    "language": "Language",
+    "popularity": "Popularity",
+    "seasons": "Seasons",
+    "episodes": "Episodes",
+    "genres": "Genres",
+    "addedBy": "Added by",
+    "memberRatings": "Member Ratings"
   }
 }
 

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -176,6 +176,30 @@
     "watching": "Assistindo",
     "watched": "Assistido",
     "dropped": "Abandonado"
+  },
+  "movieCard": {
+    "ratings_one": "avaliação",
+    "ratings_other": "avaliações",
+    "comments_one": "comentário",
+    "comments_other": "comentários",
+    "remove": "Remover",
+    "saving": "Salvando…",
+    "removing": "Removendo…",
+    "mediaType": {
+      "movie": "Filme",
+      "tv": "Série"
+    }
+  },
+  "movieOverlay": {
+    "yourRating": "Sua avaliação:",
+    "synopsis": "Sinopse",
+    "language": "Idioma",
+    "popularity": "Popularidade",
+    "seasons": "Temporadas",
+    "episodes": "Episódios",
+    "genres": "Gêneros",
+    "addedBy": "Adicionado por",
+    "memberRatings": "Avaliações dos membros"
   }
 }
 

--- a/frontend/src/pages/List.tsx
+++ b/frontend/src/pages/List.tsx
@@ -319,10 +319,6 @@ export default function ListPage() {
                   <MovieCard
                     key={item.movie_id}
                     item={item}
-                    listId={parsedId}
-                    currentUserId={currentUserId}
-                    currentUserName={currentUserName}
-                    currentUserAvatarUrl={currentUserAvatarUrl}
                     onChangeRating={handleChangeRating}
                     onChangeStatus={handleChangeStatus}
                     onDelete={handleDelete}

--- a/frontend/src/services/lists.ts
+++ b/frontend/src/services/lists.ts
@@ -126,6 +126,7 @@ export interface MovieDTO {
 export interface ListMovieUserEntryDTO {
   user_id: number
   rating?: number | null
+  notes?: string | null
   created_at: string
   updated_at: string
   user?: {


### PR DESCRIPTION
## Summary

This PR refactors the ratings display by moving the expandable section from MovieCard to MovieOverlay, improving the UX and reducing card clutter.

### Changes

**UI/UX Improvements:**
- Removed expandable ratings section from movie cards
- Added static indicators on cards showing:
  - Number of ratings (e.g., "3 avaliações")
  - Number of comments/notes (e.g., "2 comentários")
- Moved full member ratings display to the movie overlay modal
- Better visual hierarchy and information density

**Code Quality:**
- Added i18n support for all UI text (Portuguese and English)
- Simplified MovieCard component by removing unused props
- Added helper functions (`getPluralSuffix`, `getDisplayName`) for code reusability
- Added `notes` field to `ListMovieUserEntryDTO` TypeScript interface
- Improved type safety with explicit return types

**Files Modified:**
- `frontend/src/components/movie/MovieCard.tsx`
- `frontend/src/components/movie/MovieOverlay.tsx`
- `frontend/src/locales/en.json`
- `frontend/src/locales/pt.json`
- `frontend/src/pages/List.tsx`
- `frontend/src/services/lists.ts`

### Test Plan

- [x] Verify movie cards show correct rating/comment counts
- [x] Verify clicking cards opens overlay with full ratings section
- [x] Test i18n works in both Portuguese and English
- [x] Verify current user's rating is highlighted in overlay
- [x] Check responsive design on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)