### PR TITLE
Add movie streaming platforms to details overlay

### DIFF
--- a/backend/config/db.go
+++ b/backend/config/db.go
@@ -43,6 +43,7 @@ func connectDatabase() *gorm.DB {
 		&models.ListMovieUserData{},
 		&models.RefreshToken{},
 		&models.Comment{},
+		&models.WatchProvider{},
 	)
 	if err != nil {
 		panic("failed to migrate database: " + err.Error())

--- a/backend/config/dependencies.go
+++ b/backend/config/dependencies.go
@@ -16,10 +16,12 @@ var (
 	refreshTokenDAO       daos.RefreshTokenDAO
 	movieListDAO          daos.MovieListDAO
 	movieDAO              daos.MovieDAO
+	watchProviderDAO      daos.WatchProviderDAO
 	authService           services.AuthService
 	listService           services.ListService
 	searchService         services.SearchService
 	recommendationService services.RecommendationService
+	watchProviderService  services.WatchProviderService
 	authMiddleware        *middleware.AuthMiddleware
 )
 
@@ -36,6 +38,7 @@ func initializeDaos(db *gorm.DB) {
 	refreshTokenDAO = daos.NewRefreshTokenDAO(db)
 	movieListDAO = daos.NewMovieListDAO(db)
 	movieDAO = daos.NewMovieDAO(db)
+	watchProviderDAO = daos.NewWatchProviderDAO(db)
 }
 
 func initializeServices() {
@@ -43,6 +46,7 @@ func initializeServices() {
 	listService = services.NewListService(movieListDAO, movieDAO, os.Getenv("TMDB_API_TOKEN"))
 	searchService = services.NewSearchService(os.Getenv("TMDB_API_TOKEN"))
 	recommendationService = services.NewRecommendationService(movieListDAO, os.Getenv("TMDB_API_TOKEN"))
+	watchProviderService = services.NewWatchProviderService(os.Getenv("TMDB_API_TOKEN"))
 	authMiddleware = middleware.NewAuthMiddleware(authService.JWTSecret())
 }
 
@@ -54,6 +58,6 @@ func initializeControllers(router *gin.Engine) {
 	router.HEAD("/health", healthHandler)
 
 	controllers.NewAuthController(router, authService, authMiddleware)
-	controllers.NewListController(router, listService, recommendationService, authMiddleware)
+	controllers.NewListController(router, listService, recommendationService, watchProviderService, watchProviderDAO, authMiddleware)
 	controllers.NewSearchController(router, searchService, authMiddleware)
 }

--- a/backend/daos/watch_provider_dao.go
+++ b/backend/daos/watch_provider_dao.go
@@ -1,0 +1,81 @@
+package daos
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/8bury/list2gether/models"
+	"gorm.io/gorm"
+)
+
+type WatchProviderDAO interface {
+	GetCachedProviders(movieID int64, region string) (*models.WatchProvider, error)
+	UpsertProviders(movieID int64, region string, data interface{}) error
+	IsCacheExpired(provider *models.WatchProvider) bool
+}
+
+type watchProviderDAO struct {
+	db *gorm.DB
+}
+
+func NewWatchProviderDAO(db *gorm.DB) WatchProviderDAO {
+	return &watchProviderDAO{db: db}
+}
+
+const cacheExpirationDays = 14
+
+func (dao *watchProviderDAO) GetCachedProviders(movieID int64, region string) (*models.WatchProvider, error) {
+	var provider models.WatchProvider
+	err := dao.db.Where("movie_id = ? AND region = ?", movieID, region).First(&provider).Error
+	if err != nil {
+		return nil, err
+	}
+	return &provider, nil
+}
+
+func (dao *watchProviderDAO) UpsertProviders(movieID int64, region string, data interface{}) error {
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	provider := models.WatchProvider{
+		MovieID:   movieID,
+		Region:    region,
+		Data:      string(jsonData),
+		FetchedAt: now,
+		UpdatedAt: now,
+	}
+
+	// Try to update existing record first
+	result := dao.db.Model(&models.WatchProvider{}).
+		Where("movie_id = ? AND region = ?", movieID, region).
+		Updates(map[string]interface{}{
+			"data":       provider.Data,
+			"fetched_at": provider.FetchedAt,
+			"updated_at": provider.UpdatedAt,
+		})
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	// If no rows were affected, create a new record
+	if result.RowsAffected == 0 {
+		provider.CreatedAt = now
+		if err := dao.db.Create(&provider).Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (dao *watchProviderDAO) IsCacheExpired(provider *models.WatchProvider) bool {
+	if provider == nil {
+		return true
+	}
+	expirationDate := provider.FetchedAt.AddDate(0, 0, cacheExpirationDays)
+	return time.Now().After(expirationDate)
+}

--- a/backend/models/watch_provider.go
+++ b/backend/models/watch_provider.go
@@ -1,0 +1,35 @@
+package models
+
+import (
+	"time"
+)
+
+type WatchProvider struct {
+	ID         int64     `gorm:"primaryKey;autoIncrement" json:"id"`
+	MovieID    int64     `gorm:"not null;index:idx_movie_region" json:"movie_id"`
+	Region     string    `gorm:"type:char(2);not null;index:idx_movie_region" json:"region"`
+	Data       string    `gorm:"type:json;not null" json:"data"`
+	FetchedAt  time.Time `gorm:"not null" json:"fetched_at"`
+	CreatedAt  time.Time `gorm:"not null" json:"created_at"`
+	UpdatedAt  time.Time `gorm:"not null" json:"updated_at"`
+}
+
+func (WatchProvider) TableName() string {
+	return "watch_providers"
+}
+
+// WatchProviderData representa a estrutura dos dados de provedores para uma região
+type WatchProviderData struct {
+	Link     string                    `json:"link"`
+	Flatrate []WatchProviderEntry      `json:"flatrate,omitempty"`
+	Rent     []WatchProviderEntry      `json:"rent,omitempty"`
+	Buy      []WatchProviderEntry      `json:"buy,omitempty"`
+}
+
+// WatchProviderEntry representa um provedor individual
+type WatchProviderEntry struct {
+	LogoPath        string `json:"logo_path"`
+	ProviderID      int    `json:"provider_id"`
+	ProviderName    string `json:"provider_name"`
+	DisplayPriority int    `json:"display_priority"`
+}

--- a/backend/services/watch_provider_service.go
+++ b/backend/services/watch_provider_service.go
@@ -1,0 +1,88 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type WatchProviderService interface {
+	GetMovieWatchProviders(ctx context.Context, movieID int64, region string) (*WatchProviderResponse, error)
+}
+
+type watchProviderService struct {
+	client    *http.Client
+	tmdbToken string
+}
+
+func NewWatchProviderService(tmdbToken string) WatchProviderService {
+	return &watchProviderService{
+		client:    &http.Client{Timeout: 5 * time.Second},
+		tmdbToken: tmdbToken,
+	}
+}
+
+// WatchProviderResponse representa a resposta completa do TMDB
+type WatchProviderResponse struct {
+	ID      int64                           `json:"id"`
+	Results map[string]WatchProviderRegion `json:"results"`
+}
+
+// WatchProviderRegion representa os dados de uma região específica
+type WatchProviderRegion struct {
+	Link     string                  `json:"link"`
+	Flatrate []WatchProviderProvider `json:"flatrate,omitempty"`
+	Rent     []WatchProviderProvider `json:"rent,omitempty"`
+	Buy      []WatchProviderProvider `json:"buy,omitempty"`
+}
+
+// WatchProviderProvider representa um provedor individual
+type WatchProviderProvider struct {
+	LogoPath        string `json:"logo_path"`
+	ProviderID      int    `json:"provider_id"`
+	ProviderName    string `json:"provider_name"`
+	DisplayPriority int    `json:"display_priority"`
+}
+
+func (s *watchProviderService) GetMovieWatchProviders(ctx context.Context, movieID int64, region string) (*WatchProviderResponse, error) {
+	endpoint := fmt.Sprintf("https://api.themoviedb.org/3/movie/%d/watch/providers", movieID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	if s.tmdbToken != "" {
+		req.Header.Set("Authorization", "Bearer "+s.tmdbToken)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// ok
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return nil, ErrTMDBAuth
+	case http.StatusTooManyRequests:
+		return nil, ErrTMDBRateLimited
+	default:
+		if resp.StatusCode >= 500 {
+			return nil, ErrTMDBUnavailable
+		}
+		return nil, ErrTMDBUnavailable
+	}
+
+	var tmdbResp WatchProviderResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tmdbResp); err != nil {
+		return nil, err
+	}
+
+	return &tmdbResp, nil
+}

--- a/frontend/src/components/movie/MovieOverlay.tsx
+++ b/frontend/src/components/movie/MovieOverlay.tsx
@@ -36,6 +36,27 @@ interface MovieOverlayProps {
       episodes_count?: number | null
       series_status?: string | null
       genres?: Array<{ id: number; name: string }> | null
+      watch_providers?: {
+        link?: string
+        flatrate?: Array<{
+          logo_path: string
+          provider_id: number
+          provider_name: string
+          display_priority: number
+        }>
+        rent?: Array<{
+          logo_path: string
+          provider_id: number
+          provider_name: string
+          display_priority: number
+        }>
+        buy?: Array<{
+          logo_path: string
+          provider_id: number
+          provider_name: string
+          display_priority: number
+        }>
+      } | null
     }
   }
   listId: number
@@ -282,6 +303,95 @@ export function MovieOverlay({
                       {g.name}
                     </span>
                   ))}
+                </div>
+              </div>
+            )}
+
+            {/* Watch Providers */}
+            {media.watch_providers && (media.watch_providers.flatrate || media.watch_providers.rent || media.watch_providers.buy) && (
+              <div>
+                <h3 className="text-lg font-semibold text-white mb-3">{t('movieOverlay.whereToWatch')}</h3>
+                <div className="space-y-4">
+                  {media.watch_providers.flatrate && media.watch_providers.flatrate.length > 0 && (
+                    <div>
+                      <p className="text-sm text-neutral-400 mb-2">{t('movieOverlay.streaming')}</p>
+                      <div className="flex flex-wrap gap-3">
+                        {media.watch_providers.flatrate.map((provider) => (
+                          <div
+                            key={provider.provider_id}
+                            className="flex flex-col items-center gap-1 group"
+                            title={provider.provider_name}
+                          >
+                            <div className="w-12 h-12 rounded-lg overflow-hidden border border-white/10 bg-white shadow-sm group-hover:scale-110 transition-transform">
+                              <img
+                                src={`https://image.tmdb.org/t/p/original${provider.logo_path}`}
+                                alt={provider.provider_name}
+                                className="w-full h-full object-cover"
+                              />
+                            </div>
+                            <span className="text-xs text-neutral-400 text-center max-w-[60px] truncate">
+                              {provider.provider_name}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {media.watch_providers.rent && media.watch_providers.rent.length > 0 && (
+                    <div>
+                      <p className="text-sm text-neutral-400 mb-2">{t('movieOverlay.rent')}</p>
+                      <div className="flex flex-wrap gap-3">
+                        {media.watch_providers.rent.map((provider) => (
+                          <div
+                            key={provider.provider_id}
+                            className="flex flex-col items-center gap-1 group"
+                            title={provider.provider_name}
+                          >
+                            <div className="w-12 h-12 rounded-lg overflow-hidden border border-white/10 bg-white shadow-sm group-hover:scale-110 transition-transform">
+                              <img
+                                src={`https://image.tmdb.org/t/p/original${provider.logo_path}`}
+                                alt={provider.provider_name}
+                                className="w-full h-full object-cover"
+                              />
+                            </div>
+                            <span className="text-xs text-neutral-400 text-center max-w-[60px] truncate">
+                              {provider.provider_name}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {media.watch_providers.buy && media.watch_providers.buy.length > 0 && (
+                    <div>
+                      <p className="text-sm text-neutral-400 mb-2">{t('movieOverlay.buy')}</p>
+                      <div className="flex flex-wrap gap-3">
+                        {media.watch_providers.buy.map((provider) => (
+                          <div
+                            key={provider.provider_id}
+                            className="flex flex-col items-center gap-1 group"
+                            title={provider.provider_name}
+                          >
+                            <div className="w-12 h-12 rounded-lg overflow-hidden border border-white/10 bg-white shadow-sm group-hover:scale-110 transition-transform">
+                              <img
+                                src={`https://image.tmdb.org/t/p/original${provider.logo_path}`}
+                                alt={provider.provider_name}
+                                className="w-full h-full object-cover"
+                              />
+                            </div>
+                            <span className="text-xs text-neutral-400 text-center max-w-[60px] truncate">
+                              {provider.provider_name}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                  {media.watch_providers.link && (
+                    <p className="text-xs text-neutral-500">
+                      {t('movieOverlay.watchProvidersAttribution')}
+                    </p>
+                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -199,7 +199,12 @@
     "episodes": "Episodes",
     "genres": "Genres",
     "addedBy": "Added by",
-    "memberRatings": "Member Ratings"
+    "memberRatings": "Member Ratings",
+    "whereToWatch": "Where to watch",
+    "streaming": "Streaming",
+    "rent": "Rent",
+    "buy": "Buy",
+    "watchProvidersAttribution": "Data provided by JustWatch"
   }
 }
 

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -199,7 +199,12 @@
     "episodes": "Episódios",
     "genres": "Gêneros",
     "addedBy": "Adicionado por",
-    "memberRatings": "Avaliações dos membros"
+    "memberRatings": "Avaliações dos membros",
+    "whereToWatch": "Onde assistir",
+    "streaming": "Streaming",
+    "rent": "Aluguel",
+    "buy": "Comprar",
+    "watchProvidersAttribution": "Dados fornecidos por JustWatch"
   }
 }
 


### PR DESCRIPTION
Implemented watch providers integration with TMDB API to show where movies/series are available in Brazil:

Backend:
- Created WatchProvider model with 14-day cache mechanism
- Added WatchProviderService for TMDB API integration
- Added WatchProviderDAO for cache management
- Updated ListController to fetch and include watch providers in movie list endpoint
- Parallel fetching of watch providers for better performance

Frontend:
- Updated MovieOverlay to display streaming platforms (flatrate, rent, buy)
- Added provider logos with hover effects
- Added translations for watch provider labels (PT/EN)
- Included JustWatch attribution as required

The system caches watch provider data for 14 days to minimize API calls and improve performance. If cache expires, it automatically fetches fresh data from TMDB.