### PR TITLE
fix: resolve tablet focus flickering on movie cards

### DIFF
--- a/frontend/src/components/movie/MovieCard.tsx
+++ b/frontend/src/components/movie/MovieCard.tsx
@@ -105,9 +105,8 @@ export function MovieCard({ item, onChangeRating, onChangeStatus, onDelete, onOp
     <div
       ref={setNodeRef}
       style={style}
-      data-animate
       onClick={handleCardClick}
-      className="group rounded-2xl bg-gradient-to-br from-white/[0.07] to-white/[0.02] border border-white/10 overflow-hidden hover:border-white/20 hover:from-white/10 hover:to-white/[0.05] transition-all duration-300 shadow-xl shadow-black/20 hover:-translate-y-1 hover:shadow-2xl hover:shadow-black/30 cursor-pointer"
+      className="group animate-card-in rounded-2xl bg-gradient-to-br from-white/[0.07] to-white/[0.02] border border-white/10 overflow-hidden hover:border-white/20 hover:from-white/10 hover:to-white/[0.05] transition-[border-color,box-shadow] duration-300 shadow-xl shadow-black/20 hover:shadow-2xl hover:shadow-black/30 cursor-pointer"
     >
       <div className="flex">
         {/* Drag Handle */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,6 +42,34 @@
 }
 
 @layer components {
+  /* Card entrance animation - uses CSS animation to avoid conflicts with
+     focus states and dnd-kit transforms that cause flickering on tablets */
+  @keyframes card-fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .animate-card-in {
+    animation: card-fade-in 0.3s ease-out both;
+  }
+
+  /* Staggered animation delays for list items */
+  .animate-card-in:nth-child(1) { animation-delay: 0ms; }
+  .animate-card-in:nth-child(2) { animation-delay: 30ms; }
+  .animate-card-in:nth-child(3) { animation-delay: 60ms; }
+  .animate-card-in:nth-child(4) { animation-delay: 90ms; }
+  .animate-card-in:nth-child(5) { animation-delay: 120ms; }
+  .animate-card-in:nth-child(6) { animation-delay: 150ms; }
+  .animate-card-in:nth-child(7) { animation-delay: 180ms; }
+  .animate-card-in:nth-child(8) { animation-delay: 210ms; }
+  .animate-card-in:nth-child(n+9) { animation-delay: 240ms; }
+
   .auth-card {
     @apply w-full max-w-sm bg-neutral-900 border border-neutral-800 rounded-xl p-7 shadow-xl;
   }

--- a/frontend/src/pages/List.tsx
+++ b/frontend/src/pages/List.tsx
@@ -150,21 +150,8 @@ export default function ListPage() {
     loadData()
   }, [parsedId, requireAuth, clearAuth, applyItems])
 
-  // Animation on mount
-  useEffect(() => {
-    if (loading) return
-    const elements = document.querySelectorAll('[data-animate]')
-    elements.forEach((el, i) => {
-      const htmlEl = el as HTMLElement
-      htmlEl.style.opacity = '0'
-      htmlEl.style.transform = 'translateY(20px)'
-      setTimeout(() => {
-        htmlEl.style.transition = 'all 0.4s ease-out'
-        htmlEl.style.opacity = '1'
-        htmlEl.style.transform = 'translateY(0)'
-      }, i * 50)
-    })
-  }, [loading])
+  // Animation is now handled via CSS classes in MovieCard to avoid
+  // conflicts with focus states and dnd-kit transforms on tablets
 
   const handleChangeRating = async (movieId: number, value: number) => {
     if (!parsedId || Number.isNaN(parsedId) || currentUserId == null) return


### PR DESCRIPTION
The flickering was caused by conflicting CSS transitions and JavaScript
animations. When a movie card was near the top of the screen on tablets,
the browser's automatic focus handling competed with:

1. JavaScript-based entrance animation manipulating inline styles
2. transition-all on MovieCard animating ALL property changes
3. dnd-kit's transform for drag-and-drop

Solution:
- Replace JS animation with CSS @keyframes (isolated, no conflicts)
- Change transition-all to transition-[border-color,box-shadow]
- Remove hover:-translate-y-1 that conflicted with dnd-kit

https://claude.ai/code/session_014nR2urcUMsrWBvgUPb9fmj