### PR TITLE
Polish landing page mobile layout

### DIFF
--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -47,34 +47,34 @@ export default function LandingPage() {
           <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(ellipse_at_center,rgba(255,255,255,0.08),rgba(0,0,0,0)_40%)]"></div>
         </div>
 
-        <header className="absolute top-0 left-0 right-0 z-20 p-4 sm:p-6 bg-black/30 border-b border-white/10">
-          <div className="max-w-7xl mx-auto flex items-center justify-between">
-            <div className="text-lg sm:text-xl font-semibold tracking-tight">list2gether</div>
-            <nav className="flex items-center gap-2 sm:gap-3 text-xs sm:text-sm" aria-label="Primary">
+        <header className="absolute top-0 left-0 right-0 z-20 px-4 py-3 sm:p-6 bg-black/40 backdrop-blur-md border-b border-white/10 [padding-top:max(0.75rem,env(safe-area-inset-top))]">
+          <div className="max-w-7xl mx-auto flex items-center justify-between gap-3">
+            <div className="text-base sm:text-xl font-semibold tracking-tight truncate">list2gether</div>
+            <nav className="flex items-center gap-1.5 sm:gap-3 text-xs sm:text-sm shrink-0" aria-label="Primary">
               {isLoggedIn ? (
-                <Link to="/home" className="no-underline px-3 py-2 sm:px-4 sm:py-2 bg-white/10 rounded hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/40">{t('nav.lists')}</Link>
+                <Link to="/home" className="no-underline px-3 py-1.5 sm:px-4 sm:py-2 bg-white/10 rounded-md hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/40">{t('nav.lists')}</Link>
               ) : (
                 <>
-                  <Link to="/login" className="no-underline min-w-[120px] text-center px-3 py-2 sm:px-4 sm:py-2 bg-white/10 rounded hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/40">{t('nav.login')}</Link>
-                  <Link to="/registro" className="no-underline min-w-[120px] text-center px-3 py-2 sm:px-4 sm:py-2 bg-white text-black rounded hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-white/40">{t('nav.register')}</Link>
+                  <Link to="/login" className="no-underline text-center px-3 py-1.5 sm:px-4 sm:py-2 sm:min-w-[120px] bg-white/10 rounded-md hover:bg-white/20 transition-colors focus:outline-none focus:ring-2 focus:ring-white/40">{t('nav.login')}</Link>
+                  <Link to="/registro" className="no-underline text-center px-3 py-1.5 sm:px-4 sm:py-2 sm:min-w-[120px] bg-white text-black rounded-md hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-white/40">{t('nav.register')}</Link>
                 </>
               )}
             </nav>
           </div>
         </header>
         
-        <div className="relative z-10 text-center max-w-4xl mx-auto px-6">
-          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold tracking-tight leading-[1.1] pb-1 mb-4 sm:mb-6 bg-gradient-to-b from-white to-white/60 bg-clip-text text-transparent drop-shadow-[0_1px_1px_rgba(0,0,0,0.6)]">list2gether</h1>
-          <p className="text-base sm:text-lg md:text-xl text-gray-300 mb-6 sm:mb-8">{t('landing.tagline')}</p>
-          <Link 
-            to="/registro" 
-            className="no-underline inline-block px-6 py-3 sm:px-8 sm:py-4 bg-white text-black font-semibold rounded-lg hover:bg-gray-100 transition-colors shadow-lg shadow-white/10"
+        <div className="relative z-10 text-center max-w-4xl mx-auto px-5 sm:px-6 pt-16 sm:pt-0">
+          <h1 className="text-[2.75rem] leading-[1.05] sm:text-5xl md:text-6xl font-bold tracking-tight pb-1 mb-3 sm:mb-6 bg-gradient-to-b from-white to-white/60 bg-clip-text text-transparent drop-shadow-[0_1px_1px_rgba(0,0,0,0.6)]">list2gether</h1>
+          <p className="text-sm sm:text-lg md:text-xl text-gray-300 mb-6 sm:mb-8 max-w-md sm:max-w-none mx-auto">{t('landing.tagline')}</p>
+          <Link
+            to="/registro"
+            className="no-underline inline-block w-full max-w-xs sm:w-auto sm:max-w-none px-6 py-3.5 sm:px-8 sm:py-4 bg-white text-black font-semibold rounded-lg hover:bg-gray-100 active:scale-[0.98] transition-all shadow-lg shadow-white/10"
           >
             {t('landing.cta')}
           </Link>
         </div>
 
-        <div className="absolute bottom-6 left-0 right-0 z-10 flex justify-center">
+        <div className="absolute bottom-5 sm:bottom-6 left-0 right-0 z-10 hidden sm:flex justify-center [bottom:max(1.25rem,env(safe-area-inset-bottom))]">
           <a
             href="#features"
             className="group inline-flex items-center gap-2 text-gray-300 hover:text-white transition-colors no-underline"
@@ -92,111 +92,111 @@ export default function LandingPage() {
         </div>
       </section>
 
-      <section id="features" className="py-16 sm:py-20 px-4 sm:px-6">
+      <section id="features" className="py-12 sm:py-20 px-4 sm:px-6">
         <div className="max-w-7xl mx-auto">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-12 items-center mb-16 lg:mb-20">
-            <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform">
-              <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-4 md:mb-6">{t('landing.s1.title')}</h2>
-              <p className="text-gray-400 mb-6 md:mb-8">{t('landing.s1.quote')}</p>
-              <Link to="/registro" className="no-underline inline-block px-5 py-2.5 md:px-6 md:py-3 bg-white text-black rounded-lg hover:bg-gray-100 transition-colors">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-10 lg:gap-12 items-center mb-12 sm:mb-16 lg:mb-20">
+            <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform order-2 lg:order-none">
+              <h2 className="text-[1.75rem] leading-tight md:text-3xl lg:text-4xl font-bold mb-3 md:mb-6">{t('landing.s1.title')}</h2>
+              <p className="text-sm sm:text-base text-gray-400 mb-5 md:mb-8 leading-relaxed">{t('landing.s1.quote')}</p>
+              <Link to="/registro" className="no-underline inline-block px-5 py-2.5 md:px-6 md:py-3 bg-white text-black rounded-lg hover:bg-gray-100 active:scale-[0.98] transition-all">
                 {t('landing.s1.cta')}
               </Link>
             </div>
-            <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform bg-white/5 border border-white/10 rounded-lg h-48 sm:h-64 lg:h-80 flex items-center justify-center text-gray-400 overflow-hidden transition-transform hover:-translate-y-1">
+            <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform bg-white/5 border border-white/10 rounded-xl aspect-[16/10] sm:aspect-[16/9] lg:aspect-auto lg:h-80 flex items-center justify-center text-gray-400 overflow-hidden hover:-translate-y-1">
               <img src={coupleWatching} alt="Couple watching movie" className="w-full h-full object-cover" loading="lazy" />
             </div>
           </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-12 items-center mb-16 lg:mb-20">
-            <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform bg-white/5 border border-white/10 rounded-lg h-48 sm:h-64 lg:h-80 flex items-center justify-center text-gray-400 lg:order-1 overflow-hidden transition-transform hover:-translate-y-1">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-10 lg:gap-12 items-center mb-12 sm:mb-16 lg:mb-20">
+            <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform bg-white/5 border border-white/10 rounded-xl aspect-[16/10] sm:aspect-[16/9] lg:aspect-auto lg:h-80 flex items-center justify-center text-gray-400 lg:order-1 overflow-hidden hover:-translate-y-1">
               <img src={movieScene} alt="Movie scene" className="w-full h-full object-cover" loading="lazy" />
             </div>
             <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform lg:order-2">
-              <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-4 md:mb-6">{t('landing.s2.title')}</h2>
-              <p className="text-gray-400 mb-6 md:mb-8">{t('landing.s2.quote')}</p>
-              <Link to="/registro" className="no-underline inline-block px-5 py-2.5 md:px-6 md:py-3 bg-white text-black rounded-lg hover:bg-gray-100 transition-colors">
+              <h2 className="text-[1.75rem] leading-tight md:text-3xl lg:text-4xl font-bold mb-3 md:mb-6">{t('landing.s2.title')}</h2>
+              <p className="text-sm sm:text-base text-gray-400 mb-5 md:mb-8 leading-relaxed">{t('landing.s2.quote')}</p>
+              <Link to="/registro" className="no-underline inline-block px-5 py-2.5 md:px-6 md:py-3 bg-white text-black rounded-lg hover:bg-gray-100 active:scale-[0.98] transition-all">
                 {t('landing.s2.cta')}
               </Link>
             </div>
           </div>
 
-          <div className="text-center mb-20">
-            <h2 data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform text-2xl md:text-3xl lg:text-4xl font-bold mb-8 md:mb-12">{t('landing.s3.title')}</h2>
-            
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 md:gap-12">
+          <div className="text-center mb-14 sm:mb-20">
+            <h2 data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform text-[1.75rem] leading-tight md:text-3xl lg:text-4xl font-bold mb-6 sm:mb-8 md:mb-12">{t('landing.s3.title')}</h2>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8 md:gap-12">
               <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform">
-                <div className="bg-white/5 border border-white/10 rounded-lg h-56 sm:h-64 lg:h-80 mb-4 md:mb-6 flex items-center justify-center text-gray-400 overflow-hidden">
+                <div className="bg-white/5 border border-white/10 rounded-xl aspect-[4/3] sm:aspect-[16/9] lg:aspect-auto lg:h-80 mb-3 sm:mb-4 md:mb-6 flex items-center justify-center text-gray-400 overflow-hidden">
                   <img src={variousPosters} alt="Various movie posters" className="w-full h-full object-cover" loading="lazy" />
                 </div>
-                <h3 className="text-lg md:text-xl font-semibold">{t('landing.s3.card1')}</h3>
+                <h3 className="text-base sm:text-lg md:text-xl font-semibold">{t('landing.s3.card1')}</h3>
               </div>
 
-              <div className="space-y-8">
+              <div className="grid grid-cols-2 lg:grid-cols-1 gap-4 sm:gap-6 lg:gap-8 lg:space-y-0">
                 <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform">
-                  <div className="bg-white/5 border border-white/10 rounded-lg h-28 sm:h-32 md:h-36 mb-3 md:mb-4 flex items-center justify-center text-gray-400 overflow-hidden">
+                  <div className="bg-white/5 border border-white/10 rounded-xl aspect-[4/3] sm:aspect-[16/10] lg:aspect-auto lg:h-36 mb-2.5 sm:mb-3 md:mb-4 flex items-center justify-center text-gray-400 overflow-hidden">
                     <img src={interests} alt="Matching interests" className="w-full h-full object-cover" loading="lazy" />
                   </div>
-                  <h3 className="text-base md:text-lg font-semibold">{t('landing.s3.card2')}</h3>
+                  <h3 className="text-sm sm:text-base md:text-lg font-semibold">{t('landing.s3.card2')}</h3>
                 </div>
                 <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform">
-                  <div className="bg-white/5 border border-white/10 rounded-lg h-28 sm:h-32 md:h-36 mb-3 md:mb-4 flex items-center justify-center text-gray-400 overflow-hidden">
+                  <div className="bg-white/5 border border-white/10 rounded-xl aspect-[4/3] sm:aspect-[16/10] lg:aspect-auto lg:h-36 mb-2.5 sm:mb-3 md:mb-4 flex items-center justify-center text-gray-400 overflow-hidden">
                     <img src={connect} alt="Stories that connect" className="w-full h-full object-cover" loading="lazy" />
                   </div>
-                  <h3 className="text-base md:text-lg font-semibold">{t('landing.s3.card2')}</h3>
+                  <h3 className="text-sm sm:text-base md:text-lg font-semibold">{t('landing.s3.card2')}</h3>
                 </div>
               </div>
             </div>
           </div>
 
-          <div className="mb-20">
-            <h2 className="text-2xl md:text-3xl lg:text-4xl font-bold mb-8 md:mb-12">{t('landing.what.title')}</h2>
-            
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform rounded-xl bg-white/5 border border-white/10 p-6 hover:border-white/20">
-                <div className="w-8 h-8 text-white mb-4" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" fill="currentColor" className="w-8 h-8">
+          <div className="mb-14 sm:mb-20">
+            <h2 className="text-[1.75rem] leading-tight md:text-3xl lg:text-4xl font-bold mb-6 sm:mb-8 md:mb-12">{t('landing.what.title')}</h2>
+
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-6 lg:gap-8">
+              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors">
+                <div className="w-7 h-7 sm:w-8 sm:h-8 text-white mb-3 sm:mb-4" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="currentColor" className="w-7 h-7 sm:w-8 sm:h-8">
                     <path d="M4 6.75A2.75 2.75 0 0 1 6.75 4h10.5A2.75 2.75 0 0 1 20 6.75v10.5A2.75 2.75 0 0 1 17.25 20H6.75A2.75 2.75 0 0 1 4 17.25V6.75zm3.5 2a.75.75 0 0 0 0 1.5h9a.75.75 0 0 0 0-1.5h-9zm0 4a.75.75 0 0 0 0 1.5h6a.75.75 0 0 0 0-1.5h-6z"/>
                   </svg>
                 </div>
-                <h3 className="text-xl font-semibold mb-3">{t('landing.features.createLists.title')}</h3>
-                <p className="text-gray-400 text-sm">{t('landing.features.createLists.desc')}</p>
+                <h3 className="text-base sm:text-xl font-semibold mb-2 sm:mb-3">{t('landing.features.createLists.title')}</h3>
+                <p className="text-gray-400 text-xs sm:text-sm leading-relaxed">{t('landing.features.createLists.desc')}</p>
               </div>
 
-              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform delay-100 rounded-xl bg-white/5 border border-white/10 p-6 hover:border-white/20">
-                <div className="w-8 h-8 text-white mb-4" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" fill="currentColor" className="w-8 h-8">
+              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform delay-100 rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors">
+                <div className="w-7 h-7 sm:w-8 sm:h-8 text-white mb-3 sm:mb-4" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="currentColor" className="w-7 h-7 sm:w-8 sm:h-8">
                     <path d="M3.75 4A1.75 1.75 0 0 0 2 5.75v9.5C2 16.44 2.56 17 3.25 17H7v3.25a.75.75 0 0 0 1.28.53L12.06 17h8.19A1.75 1.75 0 0 0 22 15.25v-9.5A1.75 1.75 0 0 0 20.25 4H3.75zM6 8.25A.75.75 0 0 1 6.75 7.5h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 8.25zm0 3.5a.75.75 0 0 1 .75-.75h7a.75.75 0 0 1 0 1.5h-7a.75.75 0 0 1-.75-.75z"/>
                   </svg>
                 </div>
-                <h3 className="text-xl font-semibold mb-3">{t('landing.features.reviews.title')}</h3>
-                <p className="text-gray-400 text-sm">{t('landing.features.reviews.desc')}</p>
+                <h3 className="text-base sm:text-xl font-semibold mb-2 sm:mb-3">{t('landing.features.reviews.title')}</h3>
+                <p className="text-gray-400 text-xs sm:text-sm leading-relaxed">{t('landing.features.reviews.desc')}</p>
               </div>
 
-              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform delay-200 rounded-xl bg-white/5 border border-white/10 p-6 hover:border-white/20">
-                <div className="w-8 h-8 text-white mb-4" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" fill="currentColor" className="w-8 h-8">
+              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform delay-200 rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors">
+                <div className="w-7 h-7 sm:w-8 sm:h-8 text-white mb-3 sm:mb-4" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="currentColor" className="w-7 h-7 sm:w-8 sm:h-8">
                     <path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27z"/>
                   </svg>
                 </div>
-                <h3 className="text-xl font-semibold mb-3">{t('landing.features.rate.title')}</h3>
-                <p className="text-gray-400 text-sm">{t('landing.features.rate.desc')}</p>
+                <h3 className="text-base sm:text-xl font-semibold mb-2 sm:mb-3">{t('landing.features.rate.title')}</h3>
+                <p className="text-gray-400 text-xs sm:text-sm leading-relaxed">{t('landing.features.rate.desc')}</p>
               </div>
 
-              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform delay-300 rounded-xl bg-white/5 border border-white/10 p-6 hover:border-white/20">
-                <div className="w-8 h-8 text-white mb-4" aria-hidden="true">
-                  <svg viewBox="0 0 24 24" fill="currentColor" className="w-8 h-8">
+              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform delay-300 rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors">
+                <div className="w-7 h-7 sm:w-8 sm:h-8 text-white mb-3 sm:mb-4" aria-hidden="true">
+                  <svg viewBox="0 0 24 24" fill="currentColor" className="w-7 h-7 sm:w-8 sm:h-8">
                     <path d="M6.75 3A2.75 2.75 0 0 0 4 5.75v12.5A2.75 2.75 0 0 0 6.75 21h10.5A2.75 2.75 0 0 0 20 18.25V5.75A2.75 2.75 0 0 0 17.25 3H6.75zM8 7.75A.75.75 0 0 1 8.75 7h6.5a.75.75 0 0 1 0 1.5h-6.5A.75.75 0 0 1 8 7.75zM8 11.25a.75.75 0 0 1 .75-.75h6.5a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1-.75-.75zm0 3.5a.75.75 0 0 1 .75-.75h4a.75.75 0 0 1 0 1.5h-4a.75.75 0 0 1-.75-.75z"/>
                   </svg>
                 </div>
-                <h3 className="text-xl font-semibold mb-3">{t('landing.features.diary.title')}</h3>
-                <p className="text-gray-400 text-sm">{t('landing.features.diary.desc')}</p>
+                <h3 className="text-base sm:text-xl font-semibold mb-2 sm:mb-3">{t('landing.features.diary.title')}</h3>
+                <p className="text-gray-400 text-xs sm:text-sm leading-relaxed">{t('landing.features.diary.desc')}</p>
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      <footer className="border-t border-white/10 py-10 sm:py-12 px-4 sm:px-6">
+      <footer className="border-t border-white/10 py-8 sm:py-12 px-4 sm:px-6 [padding-bottom:max(2rem,env(safe-area-inset-bottom))]">
         <div className="max-w-7xl mx-auto">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
             <div>


### PR DESCRIPTION
## Summary
- Tighten header (compact buttons, backdrop blur, safe-area-inset-top) and scale hero typography so the CTA fits cleanly on small screens.
- Replace fixed image heights with aspect ratios across feature sections for consistent framing at any width.
- Lay out s3 secondary cards and the features grid two-up on mobile to cut page length, and add safe-area-inset-bottom to the footer.

## Test plan
- [ ] Open the landing page on a narrow viewport (≤375px) and verify header, hero CTA, and scroll indicator do not collide.
- [ ] Scroll through s1/s2/s3 and the features grid on mobile and confirm spacing, image ratios, and 2-column layouts render as expected.
- [ ] Verify desktop (≥lg) layout is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)