### PR TITLE
[codex] Polish landing page

### DIFF
--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -28,7 +28,8 @@
     "s3": {
       "title": "More than just watching, it's about talking and connecting.",
       "card1": "Your list, your vibe",
-      "card2": "Stories that connect"
+      "card2": "Tastes that match",
+      "card3": "Stories that connect"
     },
     "what": {
       "title": "What you can do"

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -28,7 +28,8 @@
     "s3": {
       "title": "Mais do que assistir, é sobre conversar e se conectar.",
       "card1": "Sua lista, seu estilo",
-      "card2": "Histórias que conectam"
+      "card2": "Gostos que combinam",
+      "card3": "Histórias que conectam"
     },
     "what": {
       "title": "O que você pode fazer"

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -17,15 +17,24 @@ export default function LandingPage() {
   }, [])
 
   useEffect(() => {
-    const elements = document.querySelectorAll('[data-animate]')
+    const elements = document.querySelectorAll<HTMLElement>('[data-animate]')
+    const reveal = (el: HTMLElement) => {
+      el.classList.add('opacity-100', 'translate-y-0')
+      el.classList.remove('opacity-0', 'translate-y-6')
+    }
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduced) {
+      elements.forEach(reveal)
+      return
+    }
+
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
-          const el = entry.target as HTMLElement
           if (entry.isIntersecting) {
-            el.classList.add('opacity-100', 'translate-y-0')
-            el.classList.remove('opacity-0', 'translate-y-6')
-            observer.unobserve(el)
+            reveal(entry.target as HTMLElement)
+            observer.unobserve(entry.target)
           }
         })
       },
@@ -34,14 +43,20 @@ export default function LandingPage() {
     elements.forEach((el) => observer.observe(el))
     return () => observer.disconnect()
   }, [])
+
+  const animateIn = 'opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform'
   return (
     <div className="min-h-screen w-full bg-black text-white">
       <section className="relative min-h-[100dvh] w-full flex items-center justify-center">
         <div className="absolute inset-0">
-          <img 
+          <img
             src={mainBanner}
-            alt="Hero background" 
+            alt=""
+            aria-hidden="true"
             className="w-full h-full object-cover object-center"
+            loading="eager"
+            decoding="async"
+            fetchPriority="high"
           />
           <div className="absolute inset-0 bg-gradient-to-b from-black/20 via-black/50 to-black"></div>
           <div className="absolute inset-0 pointer-events-none bg-[radial-gradient(ellipse_at_center,rgba(255,255,255,0.08),rgba(0,0,0,0)_40%)]"></div>
@@ -95,23 +110,23 @@ export default function LandingPage() {
       <section id="features" className="py-12 sm:py-20 px-4 sm:px-6">
         <div className="max-w-7xl mx-auto">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-10 lg:gap-12 items-center mb-12 sm:mb-16 lg:mb-20">
-            <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform order-2 lg:order-none">
+            <div data-animate className={`${animateIn} order-2 lg:order-none`}>
               <h2 className="text-[1.75rem] leading-tight md:text-3xl lg:text-4xl font-bold mb-3 md:mb-6">{t('landing.s1.title')}</h2>
               <p className="text-sm sm:text-base text-gray-400 mb-5 md:mb-8 leading-relaxed">{t('landing.s1.quote')}</p>
               <Link to="/registro" className="no-underline inline-block px-5 py-2.5 md:px-6 md:py-3 bg-white text-black rounded-lg hover:bg-gray-100 active:scale-[0.98] transition-all">
                 {t('landing.s1.cta')}
               </Link>
             </div>
-            <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform bg-white/5 border border-white/10 rounded-xl aspect-[16/10] sm:aspect-[16/9] lg:aspect-auto lg:h-80 flex items-center justify-center text-gray-400 overflow-hidden hover:-translate-y-1">
-              <img src={coupleWatching} alt="Couple watching movie" className="w-full h-full object-cover" loading="lazy" />
+            <div data-animate className={`${animateIn} bg-white/5 border border-white/10 rounded-xl aspect-[16/10] sm:aspect-[16/9] lg:aspect-auto lg:h-80 flex items-center justify-center text-gray-400 overflow-hidden hover:-translate-y-1`}>
+              <img src={coupleWatching} alt="Couple watching movie" className="w-full h-full object-cover" loading="lazy" decoding="async" />
             </div>
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-10 lg:gap-12 items-center mb-12 sm:mb-16 lg:mb-20">
-            <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform bg-white/5 border border-white/10 rounded-xl aspect-[16/10] sm:aspect-[16/9] lg:aspect-auto lg:h-80 flex items-center justify-center text-gray-400 lg:order-1 overflow-hidden hover:-translate-y-1">
-              <img src={movieScene} alt="Movie scene" className="w-full h-full object-cover" loading="lazy" />
+            <div data-animate className={`${animateIn} bg-white/5 border border-white/10 rounded-xl aspect-[16/10] sm:aspect-[16/9] lg:aspect-auto lg:h-80 flex items-center justify-center text-gray-400 lg:order-1 overflow-hidden hover:-translate-y-1`}>
+              <img src={movieScene} alt="Movie scene" className="w-full h-full object-cover" loading="lazy" decoding="async" />
             </div>
-            <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform lg:order-2">
+            <div data-animate className={`${animateIn} lg:order-2`}>
               <h2 className="text-[1.75rem] leading-tight md:text-3xl lg:text-4xl font-bold mb-3 md:mb-6">{t('landing.s2.title')}</h2>
               <p className="text-sm sm:text-base text-gray-400 mb-5 md:mb-8 leading-relaxed">{t('landing.s2.quote')}</p>
               <Link to="/registro" className="no-underline inline-block px-5 py-2.5 md:px-6 md:py-3 bg-white text-black rounded-lg hover:bg-gray-100 active:scale-[0.98] transition-all">
@@ -121,28 +136,28 @@ export default function LandingPage() {
           </div>
 
           <div className="text-center mb-14 sm:mb-20">
-            <h2 data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform text-[1.75rem] leading-tight md:text-3xl lg:text-4xl font-bold mb-6 sm:mb-8 md:mb-12">{t('landing.s3.title')}</h2>
+            <h2 data-animate className={`${animateIn} text-[1.75rem] leading-tight md:text-3xl lg:text-4xl font-bold mb-6 sm:mb-8 md:mb-12`}>{t('landing.s3.title')}</h2>
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 sm:gap-8 md:gap-12">
-              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform">
+              <div data-animate className={animateIn}>
                 <div className="bg-white/5 border border-white/10 rounded-xl aspect-[4/3] sm:aspect-[16/9] lg:aspect-auto lg:h-80 mb-3 sm:mb-4 md:mb-6 flex items-center justify-center text-gray-400 overflow-hidden">
-                  <img src={variousPosters} alt="Various movie posters" className="w-full h-full object-cover" loading="lazy" />
+                  <img src={variousPosters} alt="Various movie posters" className="w-full h-full object-cover" loading="lazy" decoding="async" />
                 </div>
                 <h3 className="text-base sm:text-lg md:text-xl font-semibold">{t('landing.s3.card1')}</h3>
               </div>
 
               <div className="grid grid-cols-2 lg:grid-cols-1 gap-4 sm:gap-6 lg:gap-8 lg:space-y-0">
-                <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform">
+                <div data-animate className={animateIn}>
                   <div className="bg-white/5 border border-white/10 rounded-xl aspect-[4/3] sm:aspect-[16/10] lg:aspect-auto lg:h-36 mb-2.5 sm:mb-3 md:mb-4 flex items-center justify-center text-gray-400 overflow-hidden">
-                    <img src={interests} alt="Matching interests" className="w-full h-full object-cover" loading="lazy" />
+                    <img src={interests} alt="Matching interests" className="w-full h-full object-cover" loading="lazy" decoding="async" />
                   </div>
                   <h3 className="text-sm sm:text-base md:text-lg font-semibold">{t('landing.s3.card2')}</h3>
                 </div>
-                <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform">
+                <div data-animate className={animateIn}>
                   <div className="bg-white/5 border border-white/10 rounded-xl aspect-[4/3] sm:aspect-[16/10] lg:aspect-auto lg:h-36 mb-2.5 sm:mb-3 md:mb-4 flex items-center justify-center text-gray-400 overflow-hidden">
-                    <img src={connect} alt="Stories that connect" className="w-full h-full object-cover" loading="lazy" />
+                    <img src={connect} alt="Stories that connect" className="w-full h-full object-cover" loading="lazy" decoding="async" />
                   </div>
-                  <h3 className="text-sm sm:text-base md:text-lg font-semibold">{t('landing.s3.card2')}</h3>
+                  <h3 className="text-sm sm:text-base md:text-lg font-semibold">{t('landing.s3.card3')}</h3>
                 </div>
               </div>
             </div>
@@ -152,7 +167,7 @@ export default function LandingPage() {
             <h2 className="text-[1.75rem] leading-tight md:text-3xl lg:text-4xl font-bold mb-6 sm:mb-8 md:mb-12">{t('landing.what.title')}</h2>
 
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-6 lg:gap-8">
-              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors">
+              <div data-animate className={`${animateIn} rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors`}>
                 <div className="w-7 h-7 sm:w-8 sm:h-8 text-white mb-3 sm:mb-4" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="currentColor" className="w-7 h-7 sm:w-8 sm:h-8">
                     <path d="M4 6.75A2.75 2.75 0 0 1 6.75 4h10.5A2.75 2.75 0 0 1 20 6.75v10.5A2.75 2.75 0 0 1 17.25 20H6.75A2.75 2.75 0 0 1 4 17.25V6.75zm3.5 2a.75.75 0 0 0 0 1.5h9a.75.75 0 0 0 0-1.5h-9zm0 4a.75.75 0 0 0 0 1.5h6a.75.75 0 0 0 0-1.5h-6z"/>
@@ -162,7 +177,7 @@ export default function LandingPage() {
                 <p className="text-gray-400 text-xs sm:text-sm leading-relaxed">{t('landing.features.createLists.desc')}</p>
               </div>
 
-              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform delay-100 rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors">
+              <div data-animate className={`${animateIn} delay-100 rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors`}>
                 <div className="w-7 h-7 sm:w-8 sm:h-8 text-white mb-3 sm:mb-4" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="currentColor" className="w-7 h-7 sm:w-8 sm:h-8">
                     <path d="M3.75 4A1.75 1.75 0 0 0 2 5.75v9.5C2 16.44 2.56 17 3.25 17H7v3.25a.75.75 0 0 0 1.28.53L12.06 17h8.19A1.75 1.75 0 0 0 22 15.25v-9.5A1.75 1.75 0 0 0 20.25 4H3.75zM6 8.25A.75.75 0 0 1 6.75 7.5h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 8.25zm0 3.5a.75.75 0 0 1 .75-.75h7a.75.75 0 0 1 0 1.5h-7a.75.75 0 0 1-.75-.75z"/>
@@ -172,7 +187,7 @@ export default function LandingPage() {
                 <p className="text-gray-400 text-xs sm:text-sm leading-relaxed">{t('landing.features.reviews.desc')}</p>
               </div>
 
-              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform delay-200 rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors">
+              <div data-animate className={`${animateIn} delay-200 rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors`}>
                 <div className="w-7 h-7 sm:w-8 sm:h-8 text-white mb-3 sm:mb-4" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="currentColor" className="w-7 h-7 sm:w-8 sm:h-8">
                     <path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27z"/>
@@ -182,7 +197,7 @@ export default function LandingPage() {
                 <p className="text-gray-400 text-xs sm:text-sm leading-relaxed">{t('landing.features.rate.desc')}</p>
               </div>
 
-              <div data-animate className="opacity-0 translate-y-6 transition-all duration-700 ease-out will-change-transform delay-300 rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors">
+              <div data-animate className={`${animateIn} delay-300 rounded-xl bg-white/5 border border-white/10 p-4 sm:p-6 hover:border-white/20 hover:bg-white/[0.07] transition-colors`}>
                 <div className="w-7 h-7 sm:w-8 sm:h-8 text-white mb-3 sm:mb-4" aria-hidden="true">
                   <svg viewBox="0 0 24 24" fill="currentColor" className="w-7 h-7 sm:w-8 sm:h-8">
                     <path d="M6.75 3A2.75 2.75 0 0 0 4 5.75v12.5A2.75 2.75 0 0 0 6.75 21h10.5A2.75 2.75 0 0 0 20 18.25V5.75A2.75 2.75 0 0 0 17.25 3H6.75zM8 7.75A.75.75 0 0 1 8.75 7h6.5a.75.75 0 0 1 0 1.5h-6.5A.75.75 0 0 1 8 7.75zM8 11.25a.75.75 0 0 1 .75-.75h6.5a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1-.75-.75zm0 3.5a.75.75 0 0 1 .75-.75h4a.75.75 0 0 1 0 1.5h-4a.75.75 0 0 1-.75-.75z"/>


### PR DESCRIPTION
Polishes the landing page reveal animation by sharing the animation classes and honoring reduced-motion preferences.
Improves landing imagery with eager loading for the hero, async decoding for images, and decorative hero image accessibility.
Adds separate English and Portuguese copy for the third landing card so the interests and connection cards no longer reuse the same translation.
Validated with `npm run build`; `npm run lint` still fails on pre-existing issues outside this diff.