### PR TITLE
feat(home): enrich list cards + stats bar + activity feed

### DIFF
--- a/backend/controllers/list_controller.go
+++ b/backend/controllers/list_controller.go
@@ -1867,10 +1867,10 @@ func (c *ListController) getUserActivity(ctx *gin.Context) {
 	payload := make([]gin.H, 0, len(items))
 	for _, item := range items {
 		entry := gin.H{
-			"type":       item.Type,
-			"timestamp":  item.Timestamp,
-			"list_id":    item.ListID,
-			"list_name":  item.ListName,
+			"type":      item.Type,
+			"timestamp": item.Timestamp,
+			"list_id":   item.ListID,
+			"list_name": item.ListName,
 		}
 		if item.MovieID != nil {
 			entry["movie_id"] = item.MovieID

--- a/backend/controllers/list_controller.go
+++ b/backend/controllers/list_controller.go
@@ -48,6 +48,10 @@ func NewListController(router *gin.Engine, service services.ListService, recomme
 	group.POST("/:id/movies/:movieId/comments", c.authMiddleware.Handler(), c.createComment)
 	group.PATCH("/:id/movies/:movieId/comments/:commentId", c.authMiddleware.Handler(), c.updateComment)
 	group.DELETE("/:id/movies/:movieId/comments/:commentId", c.authMiddleware.Handler(), c.deleteComment)
+	// User home routes
+	userGroup := router.Group("/api/users")
+	userGroup.GET("/stats", c.authMiddleware.Handler(), c.getUserStats)
+	userGroup.GET("/activity", c.authMiddleware.Handler(), c.getUserActivity)
 	return c
 }
 
@@ -138,19 +142,45 @@ func (c *ListController) list(ctx *gin.Context) {
 		return
 	}
 
+	listIDs := make([]int64, 0, len(memberships))
+	for _, m := range memberships {
+		listIDs = append(listIDs, m.ListID)
+	}
+	posterURLs, memberPreviews, lastActivityMap, enrichErr := c.service.FetchListEnrichments(listIDs)
+	if enrichErr != nil {
+		posterURLs = map[int64][]string{}
+		memberPreviews = map[int64][]daos.MemberPreview{}
+		lastActivityMap = map[int64]time.Time{}
+	}
+
 	lists := make([]gin.H, 0, len(memberships))
 	for _, m := range memberships {
 		l := m.List
+		lastActivity := l.UpdatedAt
+		if t, ok := lastActivityMap[l.ID]; ok && t.After(lastActivity) {
+			lastActivity = t
+		}
+		membersPayload := make([]gin.H, 0)
+		for _, mp := range memberPreviews[l.ID] {
+			membersPayload = append(membersPayload, gin.H{
+				"user_id":    mp.UserID,
+				"username":   mp.Username,
+				"avatar_url": mp.AvatarURL,
+			})
+		}
 		lists = append(lists, gin.H{
-			"id":           l.ID,
-			"name":         l.Name,
-			"description":  l.Description,
-			"invite_code":  l.InviteCode,
-			"your_role":    m.Role,
-			"created_at":   l.CreatedAt,
-			"updated_at":   l.UpdatedAt,
-			"member_count": memberCounts[l.ID],
-			"movie_count":  movieCounts[l.ID],
+			"id":               l.ID,
+			"name":             l.Name,
+			"description":      l.Description,
+			"invite_code":      l.InviteCode,
+			"your_role":        m.Role,
+			"created_at":       l.CreatedAt,
+			"updated_at":       l.UpdatedAt,
+			"member_count":     memberCounts[l.ID],
+			"movie_count":      movieCounts[l.ID],
+			"poster_urls":      posterURLs[l.ID],
+			"members":          membersPayload,
+			"last_activity_at": lastActivity,
 		})
 	}
 
@@ -1780,6 +1810,88 @@ func (c *ListController) deleteComment(ctx *gin.Context) {
 	ctx.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "Comentário excluído com sucesso",
+	})
+}
+
+func (c *ListController) getUserStats(ctx *gin.Context) {
+	rawClaims, _ := ctx.Get("auth_claims")
+	claims := rawClaims.(jwt.MapClaims)
+	sub, _ := claims["sub"].(string)
+	userID, err := strconv.ParseInt(sub, 10, 64)
+	if err != nil {
+		respondTokenInvalid(ctx)
+		return
+	}
+	stats, err := c.service.GetUserStats(userID)
+	if err != nil {
+		ctx.Header("Cache-Control", "no-store")
+		ctx.JSON(http.StatusInternalServerError, gin.H{
+			"error":     "Failed to fetch stats",
+			"code":      "INTERNAL_ERROR",
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+		})
+		return
+	}
+	ctx.Header("Cache-Control", "no-store")
+	ctx.JSON(http.StatusOK, stats)
+}
+
+func (c *ListController) getUserActivity(ctx *gin.Context) {
+	rawClaims, _ := ctx.Get("auth_claims")
+	claims := rawClaims.(jwt.MapClaims)
+	sub, _ := claims["sub"].(string)
+	userID, err := strconv.ParseInt(sub, 10, 64)
+	if err != nil {
+		respondTokenInvalid(ctx)
+		return
+	}
+	limit := 20
+	if v := ctx.Query("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			if n > 50 {
+				n = 50
+			}
+			limit = n
+		}
+	}
+	items, err := c.service.GetUserActivity(userID, limit)
+	if err != nil {
+		ctx.Header("Cache-Control", "no-store")
+		ctx.JSON(http.StatusInternalServerError, gin.H{
+			"error":     "Failed to fetch activity",
+			"code":      "INTERNAL_ERROR",
+			"timestamp": time.Now().UTC().Format(time.RFC3339),
+		})
+		return
+	}
+	payload := make([]gin.H, 0, len(items))
+	for _, item := range items {
+		entry := gin.H{
+			"type":       item.Type,
+			"timestamp":  item.Timestamp,
+			"list_id":    item.ListID,
+			"list_name":  item.ListName,
+		}
+		if item.MovieID != nil {
+			entry["movie_id"] = item.MovieID
+		}
+		if item.MovieTitle != nil {
+			entry["movie_title"] = item.MovieTitle
+		}
+		if item.MoviePosterPath != nil {
+			entry["movie_poster_url"] = item.MoviePosterPath
+		}
+		if item.UserID != nil {
+			entry["user_id"] = item.UserID
+			entry["username"] = item.Username
+			entry["avatar_url"] = item.AvatarURL
+		}
+		payload = append(payload, entry)
+	}
+	ctx.Header("Cache-Control", "no-store")
+	ctx.JSON(http.StatusOK, gin.H{
+		"activity": payload,
+		"count":    len(payload),
 	})
 }
 

--- a/backend/daos/list_dao.go
+++ b/backend/daos/list_dao.go
@@ -10,6 +10,27 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// MemberPreview is a lightweight user struct returned in batch list enrichment.
+type MemberPreview struct {
+	UserID    int64   `json:"user_id"`
+	Username  string  `json:"username"`
+	AvatarURL *string `json:"avatar_url"`
+}
+
+// ActivityItem represents one event in the user's home-page activity feed.
+type ActivityItem struct {
+	Type            string    `json:"type"`
+	Timestamp       time.Time `json:"timestamp"`
+	ListID          int64     `json:"list_id"`
+	ListName        string    `json:"list_name"`
+	MovieID         *int64    `json:"movie_id,omitempty"`
+	MovieTitle      *string   `json:"movie_title,omitempty"`
+	MoviePosterPath *string   `json:"movie_poster_path,omitempty"`
+	UserID          *int64    `json:"user_id,omitempty"`
+	Username        *string   `json:"username,omitempty"`
+	AvatarURL       *string   `json:"avatar_url,omitempty"`
+}
+
 type MovieListDAO interface {
 	InviteCodeExists(code string) (bool, error)
 	CreateWithOwner(list *models.MovieList, ownerUserID int64) error
@@ -42,6 +63,12 @@ type MovieListDAO interface {
 	FindCommentByID(commentID int64) (*models.Comment, error)
 	UpdateComment(commentID int64, content string) (*models.Comment, error)
 	DeleteComment(commentID int64) error
+	// Home enrichment methods
+	FetchPostersBatch(listIDs []int64) (map[int64][]string, error)
+	FetchMembersBatch(listIDs []int64) (map[int64][]MemberPreview, error)
+	FetchLastActivityBatch(listIDs []int64) (map[int64]time.Time, error)
+	CountWatchedThisMonth(userID int64) (int64, error)
+	FetchRecentActivity(userID int64, limit int) ([]ActivityItem, error)
 }
 
 type movieListDAO struct {
@@ -559,4 +586,187 @@ func (d *movieListDAO) UpdateComment(commentID int64, content string) (*models.C
 
 func (d *movieListDAO) DeleteComment(commentID int64) error {
 	return d.db.Delete(&models.Comment{}, commentID).Error
+}
+
+func (d *movieListDAO) FetchPostersBatch(listIDs []int64) (map[int64][]string, error) {
+	result := make(map[int64][]string)
+	if len(listIDs) == 0 {
+		return result, nil
+	}
+	type posterRow struct {
+		ListID     int64  `gorm:"column:list_id"`
+		PosterPath string `gorm:"column:poster_path"`
+	}
+	var rows []posterRow
+	if err := d.db.Table("list_movies lm").
+		Select("lm.list_id AS list_id, m.poster_path AS poster_path").
+		Joins("JOIN movies m ON m.id = lm.movie_id").
+		Where("lm.list_id IN ? AND m.poster_path IS NOT NULL AND m.poster_path != ''", listIDs).
+		Order("lm.list_id, lm.display_order ASC, lm.added_at DESC").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		if len(result[r.ListID]) < 4 {
+			result[r.ListID] = append(result[r.ListID], r.PosterPath)
+		}
+	}
+	return result, nil
+}
+
+func (d *movieListDAO) FetchMembersBatch(listIDs []int64) (map[int64][]MemberPreview, error) {
+	result := make(map[int64][]MemberPreview)
+	if len(listIDs) == 0 {
+		return result, nil
+	}
+	type memberRow struct {
+		ListID    int64   `gorm:"column:list_id"`
+		UserID    int64   `gorm:"column:user_id"`
+		Username  string  `gorm:"column:username"`
+		AvatarURL *string `gorm:"column:avatar_url"`
+	}
+	var rows []memberRow
+	if err := d.db.Table("list_members lm").
+		Select("lm.list_id AS list_id, u.id AS user_id, u.username AS username, u.avatar_url AS avatar_url").
+		Joins("JOIN users u ON u.id = lm.user_id").
+		Where("lm.list_id IN ?", listIDs).
+		Order("lm.list_id, lm.added_at ASC").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		if len(result[r.ListID]) < 5 {
+			result[r.ListID] = append(result[r.ListID], MemberPreview{
+				UserID:    r.UserID,
+				Username:  r.Username,
+				AvatarURL: r.AvatarURL,
+			})
+		}
+	}
+	return result, nil
+}
+
+func (d *movieListDAO) FetchLastActivityBatch(listIDs []int64) (map[int64]time.Time, error) {
+	result := make(map[int64]time.Time)
+	if len(listIDs) == 0 {
+		return result, nil
+	}
+	type activityTimeRow struct {
+		ListID      int64      `gorm:"column:list_id"`
+		LastAdded   *time.Time `gorm:"column:last_added"`
+		LastWatched *time.Time `gorm:"column:last_watched"`
+	}
+	var rows []activityTimeRow
+	if err := d.db.Table("list_movies").
+		Select("list_id, MAX(added_at) AS last_added, MAX(watched_at) AS last_watched").
+		Where("list_id IN ?", listIDs).
+		Group("list_id").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, r := range rows {
+		var t time.Time
+		if r.LastAdded != nil && r.LastAdded.After(t) {
+			t = *r.LastAdded
+		}
+		if r.LastWatched != nil && r.LastWatched.After(t) {
+			t = *r.LastWatched
+		}
+		if !t.IsZero() {
+			result[r.ListID] = t
+		}
+	}
+	return result, nil
+}
+
+func (d *movieListDAO) CountWatchedThisMonth(userID int64) (int64, error) {
+	now := time.Now()
+	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	var count int64
+	if err := d.db.Table("list_movies lm").
+		Joins("JOIN list_members mem ON mem.list_id = lm.list_id AND mem.user_id = ?", userID).
+		Where("lm.status = ? AND lm.watched_at >= ?", string(models.StatusWatched), firstOfMonth).
+		Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (d *movieListDAO) FetchRecentActivity(userID int64, limit int) ([]ActivityItem, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	if limit > 50 {
+		limit = 50
+	}
+	sql := `
+		(SELECT 'movie_added' AS activity_type, lm.added_at AS ts, lm.list_id, ml.name AS list_name,
+		        lm.movie_id, m.title AS movie_title, m.poster_path AS movie_poster_path,
+		        u.id AS actor_user_id, u.username AS actor_username, u.avatar_url AS actor_avatar_url
+		 FROM list_movies lm
+		 JOIN movie_lists ml ON ml.id = lm.list_id AND ml.deleted_at IS NULL
+		 JOIN movies m ON m.id = lm.movie_id
+		 LEFT JOIN users u ON u.id = lm.added_by
+		 WHERE EXISTS (SELECT 1 FROM list_members me WHERE me.list_id = lm.list_id AND me.user_id = ?))
+		UNION ALL
+		(SELECT 'movie_watched' AS activity_type, lm.watched_at AS ts, lm.list_id, ml.name AS list_name,
+		        lm.movie_id, m.title AS movie_title, m.poster_path AS movie_poster_path,
+		        NULL AS actor_user_id, NULL AS actor_username, NULL AS actor_avatar_url
+		 FROM list_movies lm
+		 JOIN movie_lists ml ON ml.id = lm.list_id AND ml.deleted_at IS NULL
+		 JOIN movies m ON m.id = lm.movie_id
+		 WHERE lm.watched_at IS NOT NULL AND lm.status = 'watched'
+		   AND EXISTS (SELECT 1 FROM list_members me WHERE me.list_id = lm.list_id AND me.user_id = ?))
+		UNION ALL
+		(SELECT 'comment' AS activity_type, c.created_at AS ts, c.list_id, ml.name AS list_name,
+		        c.movie_id, m.title AS movie_title, m.poster_path AS movie_poster_path,
+		        u.id AS actor_user_id, u.username AS actor_username, u.avatar_url AS actor_avatar_url
+		 FROM comments c
+		 JOIN movie_lists ml ON ml.id = c.list_id AND ml.deleted_at IS NULL
+		 JOIN movies m ON m.id = c.movie_id
+		 JOIN users u ON u.id = c.user_id
+		 WHERE EXISTS (SELECT 1 FROM list_members me WHERE me.list_id = c.list_id AND me.user_id = ?))
+		UNION ALL
+		(SELECT 'member_joined' AS activity_type, lm.added_at AS ts, lm.list_id, ml.name AS list_name,
+		        NULL AS movie_id, NULL AS movie_title, NULL AS movie_poster_path,
+		        u.id AS actor_user_id, u.username AS actor_username, u.avatar_url AS actor_avatar_url
+		 FROM list_members lm
+		 JOIN movie_lists ml ON ml.id = lm.list_id AND ml.deleted_at IS NULL
+		 JOIN users u ON u.id = lm.user_id
+		 WHERE EXISTS (SELECT 1 FROM list_members me WHERE me.list_id = lm.list_id AND me.user_id = ?))
+		ORDER BY ts DESC
+		LIMIT ?
+	`
+	type activityRow struct {
+		ActivityType    string     `gorm:"column:activity_type"`
+		Ts              time.Time  `gorm:"column:ts"`
+		ListID          int64      `gorm:"column:list_id"`
+		ListName        string     `gorm:"column:list_name"`
+		MovieID         *int64     `gorm:"column:movie_id"`
+		MovieTitle      *string    `gorm:"column:movie_title"`
+		MoviePosterPath *string    `gorm:"column:movie_poster_path"`
+		ActorUserID     *int64     `gorm:"column:actor_user_id"`
+		ActorUsername   *string    `gorm:"column:actor_username"`
+		ActorAvatarURL  *string    `gorm:"column:actor_avatar_url"`
+	}
+	var rows []activityRow
+	if err := d.db.Raw(sql, userID, userID, userID, userID, limit).Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+	items := make([]ActivityItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, ActivityItem{
+			Type:            r.ActivityType,
+			Timestamp:       r.Ts,
+			ListID:          r.ListID,
+			ListName:        r.ListName,
+			MovieID:         r.MovieID,
+			MovieTitle:      r.MovieTitle,
+			MoviePosterPath: r.MoviePosterPath,
+			UserID:          r.ActorUserID,
+			Username:        r.ActorUsername,
+			AvatarURL:       r.ActorAvatarURL,
+		})
+	}
+	return items, nil
 }

--- a/backend/daos/list_dao.go
+++ b/backend/daos/list_dao.go
@@ -685,6 +685,7 @@ func (d *movieListDAO) CountWatchedThisMonth(userID int64) (int64, error) {
 	var count int64
 	if err := d.db.Table("list_movies lm").
 		Joins("JOIN list_members mem ON mem.list_id = lm.list_id AND mem.user_id = ?", userID).
+		Joins("JOIN movie_lists ml ON ml.id = lm.list_id AND ml.deleted_at IS NULL").
 		Where("lm.status = ? AND lm.watched_at >= ?", string(models.StatusWatched), firstOfMonth).
 		Count(&count).Error; err != nil {
 		return 0, err

--- a/backend/daos/list_dao.go
+++ b/backend/daos/list_dao.go
@@ -738,16 +738,16 @@ func (d *movieListDAO) FetchRecentActivity(userID int64, limit int) ([]ActivityI
 		LIMIT ?
 	`
 	type activityRow struct {
-		ActivityType    string     `gorm:"column:activity_type"`
-		Ts              time.Time  `gorm:"column:ts"`
-		ListID          int64      `gorm:"column:list_id"`
-		ListName        string     `gorm:"column:list_name"`
-		MovieID         *int64     `gorm:"column:movie_id"`
-		MovieTitle      *string    `gorm:"column:movie_title"`
-		MoviePosterPath *string    `gorm:"column:movie_poster_path"`
-		ActorUserID     *int64     `gorm:"column:actor_user_id"`
-		ActorUsername   *string    `gorm:"column:actor_username"`
-		ActorAvatarURL  *string    `gorm:"column:actor_avatar_url"`
+		ActivityType    string    `gorm:"column:activity_type"`
+		Ts              time.Time `gorm:"column:ts"`
+		ListID          int64     `gorm:"column:list_id"`
+		ListName        string    `gorm:"column:list_name"`
+		MovieID         *int64    `gorm:"column:movie_id"`
+		MovieTitle      *string   `gorm:"column:movie_title"`
+		MoviePosterPath *string   `gorm:"column:movie_poster_path"`
+		ActorUserID     *int64    `gorm:"column:actor_user_id"`
+		ActorUsername   *string   `gorm:"column:actor_username"`
+		ActorAvatarURL  *string   `gorm:"column:actor_avatar_url"`
 	}
 	var rows []activityRow
 	if err := d.db.Raw(sql, userID, userID, userID, userID, limit).Scan(&rows).Error; err != nil {

--- a/backend/services/list_service.go
+++ b/backend/services/list_service.go
@@ -17,6 +17,11 @@ import (
 	"gorm.io/gorm"
 )
 
+// UserStats holds per-user statistics for the home page.
+type UserStats struct {
+	WatchedThisMonth int64 `json:"watched_this_month"`
+}
+
 type ListService interface {
 	CreateList(name string, description *string, createdBy int64) (*models.MovieList, error)
 	JoinListByInviteCode(inviteCode string, userID int64) (*models.MovieList, models.ListMemberRole, bool, int64, error)
@@ -34,6 +39,10 @@ type ListService interface {
 	GetComments(listID, userID, movieID int64, limit, offset int) ([]models.Comment, int64, error)
 	UpdateComment(listID, userID, commentID int64, content string) (*models.Comment, error)
 	DeleteComment(listID, userID, commentID int64) error
+	// Home enrichment methods
+	FetchListEnrichments(listIDs []int64) (posterURLs map[int64][]string, members map[int64][]daos.MemberPreview, lastActivity map[int64]time.Time, err error)
+	GetUserStats(userID int64) (*UserStats, error)
+	GetUserActivity(userID int64, limit int) ([]daos.ActivityItem, error)
 }
 
 type listService struct {
@@ -798,6 +807,52 @@ func (s *listService) UpdateComment(listID, userID, commentID int64, content str
 	}
 
 	return s.lists.UpdateComment(commentID, content)
+}
+
+func (s *listService) FetchListEnrichments(listIDs []int64) (map[int64][]string, map[int64][]daos.MemberPreview, map[int64]time.Time, error) {
+	posterPaths, err := s.lists.FetchPostersBatch(listIDs)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	posterURLs := make(map[int64][]string, len(posterPaths))
+	for listID, paths := range posterPaths {
+		urls := make([]string, 0, len(paths))
+		for _, p := range paths {
+			urls = append(urls, "https://image.tmdb.org/t/p/w92"+p)
+		}
+		posterURLs[listID] = urls
+	}
+	members, err := s.lists.FetchMembersBatch(listIDs)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	lastActivity, err := s.lists.FetchLastActivityBatch(listIDs)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return posterURLs, members, lastActivity, nil
+}
+
+func (s *listService) GetUserStats(userID int64) (*UserStats, error) {
+	count, err := s.lists.CountWatchedThisMonth(userID)
+	if err != nil {
+		return nil, err
+	}
+	return &UserStats{WatchedThisMonth: count}, nil
+}
+
+func (s *listService) GetUserActivity(userID int64, limit int) ([]daos.ActivityItem, error) {
+	items, err := s.lists.FetchRecentActivity(userID, limit)
+	if err != nil {
+		return nil, err
+	}
+	for i, item := range items {
+		if item.MoviePosterPath != nil && *item.MoviePosterPath != "" {
+			url := "https://image.tmdb.org/t/p/w92" + *item.MoviePosterPath
+			items[i].MoviePosterPath = &url
+		}
+	}
+	return items, nil
 }
 
 func (s *listService) DeleteComment(listID, userID, commentID int64) error {

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -100,7 +100,20 @@
     "leaveList": "Leave list",
     "confirmLeaveTitle": "Leave list?",
     "confirmLeaveText": "Are you sure you want to leave the list \"{{name}}\"? Your ratings and notes will be removed.",
-    "leaving": "Leaving…"
+    "leaving": "Leaving…",
+    "lastActivity": "{{time}} ago",
+    "justNow": "just now"
+  },
+  "home": {
+    "watchedThisMonth": "movies watched this month",
+    "recentActivity": "Recent activity",
+    "noActivity": "No activity yet",
+    "activity": {
+      "movie_added": "added {{movie}} to {{list}}",
+      "movie_watched": "{{movie}} was watched in {{list}}",
+      "comment": "commented on {{movie}} in {{list}}",
+      "member_joined": "joined list {{list}}"
+    }
   },
    "auth": {
      "email": "Email",

--- a/frontend/src/locales/pt.json
+++ b/frontend/src/locales/pt.json
@@ -100,7 +100,20 @@
     "leaveList": "Sair da lista",
     "confirmLeaveTitle": "Sair da lista?",
     "confirmLeaveText": "Tem certeza de que deseja sair da lista \"{{name}}\"? Suas avaliações e notas serão removidas.",
-    "leaving": "Saindo…"
+    "leaving": "Saindo…",
+    "lastActivity": "há {{time}}",
+    "justNow": "agora mesmo"
+  },
+  "home": {
+    "watchedThisMonth": "filmes assistidos este mês",
+    "recentActivity": "Atividade recente",
+    "noActivity": "Nenhuma atividade ainda",
+    "activity": {
+      "movie_added": "adicionou {{movie}} em {{list}}",
+      "movie_watched": "{{movie}} foi assistido em {{list}}",
+      "comment": "comentou em {{movie}} em {{list}}",
+      "member_joined": "entrou na lista {{list}}"
+    }
   },
    "auth": {
      "email": "Email",

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -316,9 +316,9 @@ export default function HomePage() {
   }
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen lg:h-dvh lg:overflow-hidden flex flex-col bg-black text-white">
       <Header />
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6 space-y-6">
+      <main className="flex-1 min-h-0 max-w-7xl w-full mx-auto px-4 sm:px-6 py-6 flex flex-col gap-6">
 
         {/* Stats bar */}
         {stats !== null && (
@@ -455,10 +455,11 @@ export default function HomePage() {
 
         {/* Main content: lists + activity feed */}
         {(loading || lists.length > 0) && (
-          <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-6 items-start">
+          <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-6 lg:flex-1 lg:min-h-0">
 
             {/* Lists column */}
-            <ul className="space-y-3">
+            <div className="lg:overflow-y-auto lg:min-h-0">
+              <ul className="space-y-3">
               {loading
                 ? [0, 1, 2].map((i) => <SkeletonListItem key={i} />)
                 : lists.map((list) => {
@@ -565,33 +566,41 @@ export default function HomePage() {
                       </li>
                     )
                   })}
-            </ul>
+              </ul>
+            </div>
 
             {/* Activity feed */}
-            <div className="rounded-xl border border-white/10 bg-white/5 p-4 lg:sticky lg:top-6">
-              <h3 className="text-sm font-semibold text-white/80 mb-3">{t('home.recentActivity')}</h3>
-              {loading ? (
-                <div className="space-y-3">
-                  {[0, 1, 2, 4].map((i) => (
-                    <div key={i} className="flex gap-3 animate-pulse">
-                      <Skeleton className="w-8 h-11 rounded bg-white/10 shrink-0" />
-                      <div className="flex-1 space-y-1.5">
-                        <Skeleton className="h-3 w-3/4 bg-white/10" />
-                        <Skeleton className="h-3 w-1/2 bg-white/10" />
-                        <Skeleton className="h-2 w-1/4 bg-white/10" />
+            <div className="rounded-xl border border-white/10 bg-white/5 flex flex-col overflow-hidden lg:min-h-0">
+              <div className="px-4 pt-4 pb-3 shrink-0 border-b border-white/5">
+                <h3 className="text-sm font-semibold text-white/80">{t('home.recentActivity')}</h3>
+              </div>
+              <div
+                className="overflow-y-auto min-h-0 px-4 pb-4 flex-1 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full hover:[&::-webkit-scrollbar-thumb]:bg-white/20"
+                style={{ scrollbarWidth: 'thin', scrollbarColor: 'rgba(255,255,255,0.1) transparent' }}
+              >
+                {loading ? (
+                  <div className="space-y-3 pt-3">
+                    {[0, 1, 2, 4].map((i) => (
+                      <div key={i} className="flex gap-3 animate-pulse">
+                        <Skeleton className="w-8 h-11 rounded bg-white/10 shrink-0" />
+                        <div className="flex-1 space-y-1.5">
+                          <Skeleton className="h-3 w-3/4 bg-white/10" />
+                          <Skeleton className="h-3 w-1/2 bg-white/10" />
+                          <Skeleton className="h-2 w-1/4 bg-white/10" />
+                        </div>
                       </div>
-                    </div>
-                  ))}
-                </div>
-              ) : activity.length === 0 ? (
-                <p className="text-xs text-neutral-500">{t('home.noActivity')}</p>
-              ) : (
-                <div>
-                  {activity.map((item, i) => (
-                    <ActivityFeedItem key={i} item={item} />
-                  ))}
-                </div>
-              )}
+                    ))}
+                  </div>
+                ) : activity.length === 0 ? (
+                  <p className="text-xs text-neutral-500 pt-3">{t('home.noActivity')}</p>
+                ) : (
+                  <div className="pt-1">
+                    {activity.map((item, i) => (
+                      <ActivityFeedItem key={i} item={item} />
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
 
           </div>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -320,26 +320,20 @@ export default function HomePage() {
       <Header />
       <main className="flex-1 min-h-0 max-w-7xl w-full mx-auto px-4 sm:px-6 py-6 flex flex-col gap-6">
 
-        {/* Stats bar */}
-        {stats !== null && (
-          <div className="flex gap-3">
-            <div className="inline-flex items-center gap-3 rounded-xl bg-white/5 border border-white/10 px-4 py-3">
-              <div className="w-9 h-9 rounded-lg bg-blue-500/20 flex items-center justify-center shrink-0">
-                <Film className="w-4.5 h-4.5 text-blue-400" />
-              </div>
-              <div>
-                <p className="text-2xl font-bold leading-none">{stats.watched_this_month}</p>
-                <p className="text-xs text-neutral-400 mt-0.5">{t('home.watchedThisMonth')}</p>
-              </div>
-            </div>
-          </div>
-        )}
-
         {/* Header row */}
         <div className="flex items-center justify-between gap-3">
-          <h2 className="text-2xl md:text-3xl font-bold tracking-tight bg-gradient-to-b from-white to-white/60 bg-clip-text text-transparent">
-            {t('lists.title')}
-          </h2>
+          <div>
+            <h2 className="text-2xl md:text-3xl font-bold tracking-tight bg-gradient-to-b from-white to-white/60 bg-clip-text text-transparent">
+              {t('lists.title')}
+            </h2>
+            {stats !== null && (
+              <p className="flex items-center gap-1.5 mt-1 text-sm text-neutral-500">
+                <Film className="w-3.5 h-3.5 text-blue-400 shrink-0" />
+                <span className="text-white/80 font-medium tabular-nums">{stats.watched_this_month}</span>
+                {t('home.watchedThisMonth')}
+              </p>
+            )}
+          </div>
 
           <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
             <PopoverTrigger asChild>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,15 +1,172 @@
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { Plus, Copy, Check, ArrowRight, Trash2, LogOut, Crown, User } from 'lucide-react'
+import { Plus, Copy, Check, ArrowRight, Trash2, LogOut, Crown, User, Film, Eye, MessageSquare, UserPlus, Clapperboard } from 'lucide-react'
 import Header from '@/components/Header'
+import { UserAvatar } from '@/components/UserAvatar'
 import { ConfirmDialog } from '@/components/ConfirmDialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useAuth } from '@/hooks'
-import { getUserLists, createList, joinList, deleteList, leaveList, type UserListDTO } from '@/services/lists'
+import {
+  getUserLists,
+  createList,
+  joinList,
+  deleteList,
+  leaveList,
+  getUserStats,
+  getUserActivity,
+  type UserListDTO,
+  type UserStatsDTO,
+  type ActivityItemDTO,
+} from '@/services/lists'
 import type { ApiException } from '@/services/api'
+
+function relativeTime(dateStr: string): { value: string; isJustNow: boolean } {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const s = Math.floor(diff / 1000)
+  const m = Math.floor(s / 60)
+  const h = Math.floor(m / 60)
+  const d = Math.floor(h / 24)
+  const mo = Math.floor(d / 30)
+  const y = Math.floor(d / 365)
+  if (s < 60) return { value: '', isJustNow: true }
+  if (m < 60) return { value: `${m}min`, isJustNow: false }
+  if (h < 24) return { value: `${h}h`, isJustNow: false }
+  if (d < 30) return { value: `${d}d`, isJustNow: false }
+  if (mo < 12) return { value: `${mo}m`, isJustNow: false }
+  return { value: `${y}a`, isJustNow: false }
+}
+
+function PosterStack({ urls }: { urls?: string[] | null }) {
+  const filled = (urls ?? []).slice(0, 4)
+  if (filled.length === 0) {
+    return (
+      <div className="flex items-center justify-center w-[88px] h-[60px] rounded-lg bg-white/5 border border-white/10 shrink-0">
+        <Clapperboard className="w-5 h-5 text-white/20" />
+      </div>
+    )
+  }
+  return (
+    <div className="flex -space-x-2 shrink-0">
+      {filled.map((url, i) => (
+        <div
+          key={i}
+          className="w-10 h-14 rounded-md overflow-hidden border border-white/20 shrink-0 shadow-md"
+          style={{ zIndex: filled.length - i }}
+        >
+          <img src={url} alt="" className="w-full h-full object-cover" draggable={false} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function MemberAvatars({ members }: { members?: { user_id: number; username: string; avatar_url?: string | null }[] | null }) {
+  const list = (members ?? []).slice(0, 4)
+  if (list.length === 0) return null
+  return (
+    <div className="flex -space-x-1.5">
+      {list.map((m) => (
+        <UserAvatar key={m.user_id} name={m.username} avatarUrl={m.avatar_url} size="xs" className="ring-1 ring-black" />
+      ))}
+    </div>
+  )
+}
+
+function SkeletonListItem() {
+  return (
+    <li className="rounded-xl border border-white/10 bg-white/5 p-4 sm:p-5 animate-pulse">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-3 flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <Skeleton className="h-5 w-48 bg-white/10" />
+            <Skeleton className="h-5 w-5 rounded-full bg-white/10" />
+          </div>
+          <Skeleton className="h-3 w-2/3 bg-white/10" />
+          <div className="flex gap-2">
+            <Skeleton className="h-6 w-20 rounded-full bg-white/10" />
+            <Skeleton className="h-6 w-24 rounded-full bg-white/10" />
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="flex -space-x-1.5">
+              {[0, 1, 2].map((i) => <Skeleton key={i} className="w-6 h-6 rounded-full bg-white/10" />)}
+            </div>
+            <Skeleton className="h-3 w-16 bg-white/10" />
+          </div>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <Skeleton className="h-9 w-9 rounded-md bg-white/10" />
+          <Skeleton className="h-9 w-9 rounded-md bg-white/10" />
+        </div>
+      </div>
+    </li>
+  )
+}
+
+function ActivityIcon({ type }: { type: ActivityItemDTO['type'] }) {
+  const base = 'w-4 h-4'
+  switch (type) {
+    case 'movie_added': return <Plus className={`${base} text-emerald-400`} />
+    case 'movie_watched': return <Eye className={`${base} text-blue-400`} />
+    case 'comment': return <MessageSquare className={`${base} text-violet-400`} />
+    case 'member_joined': return <UserPlus className={`${base} text-amber-400`} />
+  }
+}
+
+function ActivityFeedItem({ item }: { item: ActivityItemDTO }) {
+  const { t } = useTranslation()
+  const rt = relativeTime(item.timestamp)
+  const timeStr = rt.isJustNow ? t('lists.justNow') : t('lists.lastActivity', { time: rt.value })
+
+  let description: string
+  switch (item.type) {
+    case 'movie_added':
+      description = item.username
+        ? t('home.activity.movie_added', { movie: item.movie_title ?? '?', list: item.list_name })
+        : t('home.activity.movie_added', { movie: item.movie_title ?? '?', list: item.list_name })
+      break
+    case 'movie_watched':
+      description = t('home.activity.movie_watched', { movie: item.movie_title ?? '?', list: item.list_name })
+      break
+    case 'comment':
+      description = t('home.activity.comment', { movie: item.movie_title ?? '?', list: item.list_name })
+      break
+    case 'member_joined':
+      description = t('home.activity.member_joined', { list: item.list_name })
+      break
+  }
+
+  return (
+    <div className="flex items-start gap-3 py-2.5 border-b border-white/5 last:border-0">
+      {item.movie_poster_url ? (
+        <div className="w-8 h-11 rounded overflow-hidden shrink-0 bg-white/5">
+          <img src={item.movie_poster_url} alt="" className="w-full h-full object-cover" draggable={false} />
+        </div>
+      ) : item.username ? (
+        <div className="shrink-0 mt-0.5">
+          <UserAvatar name={item.username} avatarUrl={item.avatar_url} size="xs" />
+        </div>
+      ) : (
+        <div className="w-8 h-8 rounded-full bg-white/5 flex items-center justify-center shrink-0 mt-0.5">
+          <ActivityIcon type={item.type} />
+        </div>
+      )}
+      <div className="flex-1 min-w-0">
+        {item.username && (
+          <p className="text-xs font-semibold text-white/90 truncate leading-tight">{item.username}</p>
+        )}
+        <p className="text-xs text-neutral-400 leading-snug line-clamp-2">{description}</p>
+        <p className="text-[10px] text-neutral-600 mt-0.5">{timeStr}</p>
+      </div>
+      <div className="shrink-0 mt-0.5">
+        <ActivityIcon type={item.type} />
+      </div>
+    </div>
+  )
+}
 
 export default function HomePage() {
   const navigate = useNavigate()
@@ -20,6 +177,8 @@ export default function HomePage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [copiedId, setCopiedId] = useState<number | null>(null)
+  const [stats, setStats] = useState<UserStatsDTO | null>(null)
+  const [activity, setActivity] = useState<ActivityItemDTO[]>([])
 
   // Create/Join states
   const [popoverOpen, setPopoverOpen] = useState(false)
@@ -41,15 +200,21 @@ export default function HomePage() {
       setLoading(true)
       setError(null)
       try {
-        const res = await getUserLists()
-        setLists(res.lists)
-      } catch (err) {
-        const apiErr = err as ApiException
-        const message = apiErr.payload?.error || apiErr.message || 'Falha ao carregar listas'
-        setError(message)
-        if (apiErr.status === 401) {
-          clearAuth()
+        const [listsRes, statsRes, activityRes] = await Promise.allSettled([
+          getUserLists(),
+          getUserStats(),
+          getUserActivity(20),
+        ])
+        if (listsRes.status === 'fulfilled') {
+          setLists(listsRes.value.lists)
+        } else {
+          const apiErr = listsRes.reason as ApiException
+          const message = apiErr.payload?.error || apiErr.message || 'Falha ao carregar listas'
+          setError(message)
+          if (apiErr.status === 401) clearAuth()
         }
+        if (statsRes.status === 'fulfilled') setStats(statsRes.value)
+        if (activityRes.status === 'fulfilled') setActivity(activityRes.value.activity ?? [])
       } finally {
         setLoading(false)
       }
@@ -77,9 +242,7 @@ export default function HomePage() {
       const apiErr = err as ApiException
       const message = apiErr.payload?.error || apiErr.message || 'Falha ao excluir lista'
       setError(message)
-      if (apiErr.status === 401) {
-        clearAuth()
-      }
+      if (apiErr.status === 401) clearAuth()
     } finally {
       setDeleting(false)
     }
@@ -96,9 +259,7 @@ export default function HomePage() {
       const apiErr = err as ApiException
       const message = apiErr.payload?.error || apiErr.message || 'Falha ao sair da lista'
       setError(message)
-      if (apiErr.status === 401) {
-        clearAuth()
-      }
+      if (apiErr.status === 401) clearAuth()
     } finally {
       setLeaving(false)
     }
@@ -116,53 +277,66 @@ export default function HomePage() {
     }
   }
 
-   const handleCreate = async () => {
-     if (!createName.trim()) return
-     setCreating(true)
-     try {
-       await createList({ name: createName.trim(), description: createDescription.trim() || undefined })
-       setCreateName('')
-       setCreateDescription('')
-       setPopoverOpen(false)
-       const res = await getUserLists()
-       setLists(res.lists)
-     } catch (err) {
-       const apiErr = err as ApiException
-       const message = apiErr.payload?.error || apiErr.message
-       setError(message)
-       if (apiErr.status === 401) {
-         clearAuth()
-       }
-     } finally {
-       setCreating(false)
-     }
-   }
+  const handleCreate = async () => {
+    if (!createName.trim()) return
+    setCreating(true)
+    try {
+      await createList({ name: createName.trim(), description: createDescription.trim() || undefined })
+      setCreateName('')
+      setCreateDescription('')
+      setPopoverOpen(false)
+      const res = await getUserLists()
+      setLists(res.lists)
+    } catch (err) {
+      const apiErr = err as ApiException
+      const message = apiErr.payload?.error || apiErr.message
+      setError(message)
+      if (apiErr.status === 401) clearAuth()
+    } finally {
+      setCreating(false)
+    }
+  }
 
-   const handleJoin = async () => {
-     if (!inviteCode.trim()) return
-     setJoining(true)
-     try {
-       const res = await joinList(inviteCode.trim())
-       setInviteCode('')
-       setPopoverOpen(false)
-       navigate(`/list/${res.list.id}`)
-     } catch (err) {
-       const apiErr = err as ApiException
-       const message = apiErr.payload?.error || apiErr.message
-       setError(message)
-       if (apiErr.status === 401) {
-         clearAuth()
-       }
-     } finally {
-       setJoining(false)
-     }
-   }
+  const handleJoin = async () => {
+    if (!inviteCode.trim()) return
+    setJoining(true)
+    try {
+      const res = await joinList(inviteCode.trim())
+      setInviteCode('')
+      setPopoverOpen(false)
+      navigate(`/list/${res.list.id}`)
+    } catch (err) {
+      const apiErr = err as ApiException
+      const message = apiErr.payload?.error || apiErr.message
+      setError(message)
+      if (apiErr.status === 401) clearAuth()
+    } finally {
+      setJoining(false)
+    }
+  }
 
   return (
     <div className="min-h-screen bg-black text-white">
       <Header />
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6">
-        <div className="flex items-center justify-between mb-5 gap-3">
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 py-6 space-y-6">
+
+        {/* Stats bar */}
+        {stats !== null && (
+          <div className="flex gap-3">
+            <div className="inline-flex items-center gap-3 rounded-xl bg-white/5 border border-white/10 px-4 py-3">
+              <div className="w-9 h-9 rounded-lg bg-blue-500/20 flex items-center justify-center shrink-0">
+                <Film className="w-4.5 h-4.5 text-blue-400" />
+              </div>
+              <div>
+                <p className="text-2xl font-bold leading-none">{stats.watched_this_month}</p>
+                <p className="text-xs text-neutral-400 mt-0.5">{t('home.watchedThisMonth')}</p>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Header row */}
+        <div className="flex items-center justify-between gap-3">
           <h2 className="text-2xl md:text-3xl font-bold tracking-tight bg-gradient-to-b from-white to-white/60 bg-clip-text text-transparent">
             {t('lists.title')}
           </h2>
@@ -170,9 +344,7 @@ export default function HomePage() {
           <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
             <PopoverTrigger asChild>
               <Button
-                onClick={() => {
-                  if (!popoverOpen) openPopover('create')
-                }}
+                onClick={() => { if (!popoverOpen) openPopover('create') }}
                 className="gap-2"
               >
                 <Plus className={`w-4 h-4 transition-transform duration-200 ${popoverOpen ? 'rotate-45' : ''}`} />
@@ -180,45 +352,26 @@ export default function HomePage() {
               </Button>
             </PopoverTrigger>
             <PopoverContent align="end" className="w-80 p-0">
-              {/* Segmented control */}
               <div className="p-3 pb-0">
                 <div className="relative flex p-1 rounded-full bg-white/5">
                   <div
                     className="absolute top-1 bottom-1 w-[calc(50%-4px)] bg-white rounded-full shadow-lg transition-all duration-300 ease-out"
-                    style={{
-                      left: popoverMode === 'create' ? '4px' : 'calc(50% + 0px)',
-                    }}
+                    style={{ left: popoverMode === 'create' ? '4px' : 'calc(50% + 0px)' }}
                   />
                   <button
-                    className={`relative flex-1 py-2 text-sm font-medium rounded-full transition-colors duration-200 z-10 ${
-                      popoverMode === 'create'
-                        ? 'text-black'
-                        : 'text-neutral-400 hover:text-white'
-                    }`}
-                    onClick={() => {
-                      setPopoverMode('create')
-                      setError(null)
-                    }}
+                    className={`relative flex-1 py-2 text-sm font-medium rounded-full transition-colors duration-200 z-10 ${popoverMode === 'create' ? 'text-black' : 'text-neutral-400 hover:text-white'}`}
+                    onClick={() => { setPopoverMode('create'); setError(null) }}
                   >
                     {t('lists.popover.create')}
                   </button>
                   <button
-                    className={`relative flex-1 py-2 text-sm font-medium rounded-full transition-colors duration-200 z-10 ${
-                      popoverMode === 'join'
-                        ? 'text-black'
-                        : 'text-neutral-400 hover:text-white'
-                    }`}
-                    onClick={() => {
-                      setPopoverMode('join')
-                      setError(null)
-                    }}
+                    className={`relative flex-1 py-2 text-sm font-medium rounded-full transition-colors duration-200 z-10 ${popoverMode === 'join' ? 'text-black' : 'text-neutral-400 hover:text-white'}`}
+                    onClick={() => { setPopoverMode('join'); setError(null) }}
                   >
                     {t('lists.popover.join')}
                   </button>
                 </div>
               </div>
-
-              {/* Form content */}
               <div className="p-4 space-y-3">
                 {popoverMode === 'create' ? (
                   <>
@@ -247,38 +400,27 @@ export default function HomePage() {
                     autoFocus
                   />
                 )}
-
                 {error && (
                   <div className="text-sm text-rose-400 bg-rose-500/10 border border-rose-500/20 rounded-lg px-3 py-2">
                     {error}
                   </div>
                 )}
-
                 <Button
                   className="w-full"
-                  disabled={
-                    popoverMode === 'create'
-                      ? creating || createName.trim().length === 0
-                      : joining || inviteCode.trim().length === 0
-                  }
+                  disabled={popoverMode === 'create' ? creating || createName.trim().length === 0 : joining || inviteCode.trim().length === 0}
                   onClick={popoverMode === 'create' ? handleCreate : handleJoin}
                 >
                   {popoverMode === 'create'
-                    ? creating
-                      ? t('lists.creating')
-                      : t('lists.create')
-                    : joining
-                    ? t('lists.joining')
-                    : t('lists.join')}
+                    ? creating ? t('lists.creating') : t('lists.create')
+                    : joining ? t('lists.joining') : t('lists.join')}
                 </Button>
               </div>
             </PopoverContent>
           </Popover>
         </div>
 
-        {loading && <div className="text-neutral-300">{t('misc.loading')}</div>}
         {error && !popoverOpen && (
-          <div className="rounded-lg bg-white/5 border border-white/10 p-3 text-sm text-rose-300 max-w-lg mb-4">
+          <div className="rounded-lg bg-white/5 border border-white/10 p-3 text-sm text-rose-300 max-w-lg">
             {error}
           </div>
         )}
@@ -296,7 +438,6 @@ export default function HomePage() {
               <h3 className="text-xl font-semibold mb-2">{t('lists.empty.createFirst')}</h3>
               <p className="text-neutral-400 text-sm">{t('lists.empty.createDesc')}</p>
             </button>
-
             <button
               onClick={() => openPopover('join')}
               className="group text-left rounded-2xl bg-gradient-to-br from-blue-600/20 to-blue-600/5 border border-blue-500/20 p-6 hover:border-blue-500/40 hover:scale-[1.02] transition-all focus:outline-none focus:ring-2 focus:ring-blue-500/40"
@@ -312,101 +453,151 @@ export default function HomePage() {
           </div>
         )}
 
-        {/* Lists */}
-        <ul className="space-y-3">
-          {lists.map((list) => (
-            <li
-              key={list.id}
-              className="group rounded-xl border border-white/10 bg-white/5 hover:border-white/20 hover:bg-white/10 transition-all p-4 sm:p-5 shadow-lg shadow-white/10 hover:-translate-y-0.5"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <span className="text-lg font-semibold tracking-tight">{list.name}</span>
-                    {list.your_role === 'owner' ? (
-                      <span
-                        className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-white/10 border border-white/10 text-amber-300"
-                        title="Owner"
-                        aria-label="Owner"
-                      >
-                        <Crown className="w-3.5 h-3.5" />
-                      </span>
-                    ) : (
-                      <span
-                        className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-white/10 border border-white/10 text-blue-300"
-                        title="Participant"
-                        aria-label="Participant"
-                      >
-                        <User className="w-3.5 h-3.5" />
-                      </span>
-                    )}
-                  </div>
-                  {list.description && (
-                    <p className="text-sm text-neutral-300 line-clamp-2">{list.description}</p>
-                  )}
-                  <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-200">
-                    <span className="inline-flex items-center gap-1 rounded-full bg-white/10 border border-white/10 px-2 py-1">
-                      {t('lists.counts.movies')}: {list.movie_count}
-                    </span>
-                    <span className="inline-flex items-center gap-1 rounded-full bg-white/10 border border-white/10 px-2 py-1">
-                      {t('lists.counts.participants')}: {list.member_count}
-                    </span>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2 shrink-0">
-                  <Button
-                    variant="secondary"
-                    size="icon"
-                    onClick={() => handleCopy(list)}
-                    aria-label={copiedId === list.id ? t('lists.codeCopied') : t('lists.copyCode')}
-                    title={copiedId === list.id ? t('lists.codeCopied') : t('lists.copyCode')}
-                  >
-                    {copiedId === list.id ? (
-                      <Check className="w-5 h-5 text-emerald-300" />
-                    ) : (
-                      <Copy className="w-5 h-5" />
-                    )}
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    size="icon"
-                    onClick={() => navigate(`/list/${list.id}`)}
-                    aria-label={t('lists.openList')}
-                    title={t('lists.openList')}
-                  >
-                    <ArrowRight className="w-5 h-5" />
-                  </Button>
-                  {list.your_role === 'owner' && (
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      onClick={() => setConfirmDelete(list)}
-                      className="border-rose-400/30 bg-rose-500/10 hover:bg-rose-500/20 text-rose-300"
-                      aria-label={t('lists.deleteList')}
-                      title={t('lists.deleteList')}
-                    >
-                      <Trash2 className="w-5 h-5" />
-                    </Button>
-                  )}
-                  {list.your_role === 'participant' && (
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      onClick={() => setConfirmLeave(list)}
-                      className="border-amber-400/30 bg-amber-500/10 hover:bg-amber-500/20 text-amber-300"
-                      aria-label={t('lists.leaveList')}
-                      title={t('lists.leaveList')}
-                    >
-                      <LogOut className="w-5 h-5" />
-                    </Button>
-                  )}
-                </div>
-              </div>
-            </li>
-          ))}
-        </ul>
+        {/* Main content: lists + activity feed */}
+        {(loading || lists.length > 0) && (
+          <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px] gap-6 items-start">
 
-        {/* Delete confirmation dialog */}
+            {/* Lists column */}
+            <ul className="space-y-3">
+              {loading
+                ? [0, 1, 2].map((i) => <SkeletonListItem key={i} />)
+                : lists.map((list) => {
+                    const rt = list.last_activity_at ? relativeTime(list.last_activity_at) : null
+                    const lastActivityStr = rt
+                      ? rt.isJustNow
+                        ? t('lists.justNow')
+                        : t('lists.lastActivity', { time: rt.value })
+                      : null
+
+                    return (
+                      <li
+                        key={list.id}
+                        className="group rounded-xl border border-white/10 bg-white/5 hover:border-white/20 hover:bg-white/[0.07] transition-all p-4 sm:p-5 shadow-lg shadow-black/20 hover:-translate-y-0.5"
+                      >
+                        <div className="flex items-start gap-4">
+                          {/* Poster stack */}
+                          <div className="hidden sm:block pt-0.5">
+                            <PosterStack urls={list.poster_urls} />
+                          </div>
+
+                          {/* Content */}
+                          <div className="flex-1 min-w-0 space-y-2">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <span className="text-base font-semibold tracking-tight truncate">{list.name}</span>
+                              {list.your_role === 'owner' ? (
+                                <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-white/10 border border-white/10 text-amber-300" title="Owner">
+                                  <Crown className="w-3 h-3" />
+                                </span>
+                              ) : (
+                                <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-white/10 border border-white/10 text-blue-300" title="Participant">
+                                  <User className="w-3 h-3" />
+                                </span>
+                              )}
+                            </div>
+                            {list.description && (
+                              <p className="text-xs text-neutral-400 line-clamp-1">{list.description}</p>
+                            )}
+                            <div className="flex flex-wrap items-center gap-2 text-xs text-neutral-300">
+                              <span className="inline-flex items-center gap-1 rounded-full bg-white/10 border border-white/10 px-2 py-0.5">
+                                {t('lists.counts.movies')}: {list.movie_count}
+                              </span>
+                              <span className="inline-flex items-center gap-1 rounded-full bg-white/10 border border-white/10 px-2 py-0.5">
+                                {t('lists.counts.participants')}: {list.member_count}
+                              </span>
+                            </div>
+                            <div className="flex items-center justify-between flex-wrap gap-2">
+                              <div className="flex items-center gap-2">
+                                <MemberAvatars members={list.members} />
+                                {lastActivityStr && (
+                                  <span className="text-[11px] text-neutral-500">{lastActivityStr}</span>
+                                )}
+                              </div>
+                              {/* Action buttons */}
+                              <div className="flex items-center gap-1.5 shrink-0">
+                                <Button
+                                  variant="secondary"
+                                  size="icon"
+                                  className="w-8 h-8"
+                                  onClick={() => handleCopy(list)}
+                                  aria-label={copiedId === list.id ? t('lists.codeCopied') : t('lists.copyCode')}
+                                  title={copiedId === list.id ? t('lists.codeCopied') : t('lists.copyCode')}
+                                >
+                                  {copiedId === list.id ? <Check className="w-4 h-4 text-emerald-300" /> : <Copy className="w-4 h-4" />}
+                                </Button>
+                                <Button
+                                  variant="secondary"
+                                  size="icon"
+                                  className="w-8 h-8"
+                                  onClick={() => navigate(`/list/${list.id}`)}
+                                  aria-label={t('lists.openList')}
+                                  title={t('lists.openList')}
+                                >
+                                  <ArrowRight className="w-4 h-4" />
+                                </Button>
+                                {list.your_role === 'owner' && (
+                                  <Button
+                                    variant="outline"
+                                    size="icon"
+                                    className="w-8 h-8 border-rose-400/30 bg-rose-500/10 hover:bg-rose-500/20 text-rose-300"
+                                    onClick={() => setConfirmDelete(list)}
+                                    aria-label={t('lists.deleteList')}
+                                    title={t('lists.deleteList')}
+                                  >
+                                    <Trash2 className="w-4 h-4" />
+                                  </Button>
+                                )}
+                                {list.your_role === 'participant' && (
+                                  <Button
+                                    variant="outline"
+                                    size="icon"
+                                    className="w-8 h-8 border-amber-400/30 bg-amber-500/10 hover:bg-amber-500/20 text-amber-300"
+                                    onClick={() => setConfirmLeave(list)}
+                                    aria-label={t('lists.leaveList')}
+                                    title={t('lists.leaveList')}
+                                  >
+                                    <LogOut className="w-4 h-4" />
+                                  </Button>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </li>
+                    )
+                  })}
+            </ul>
+
+            {/* Activity feed */}
+            <div className="rounded-xl border border-white/10 bg-white/5 p-4 lg:sticky lg:top-6">
+              <h3 className="text-sm font-semibold text-white/80 mb-3">{t('home.recentActivity')}</h3>
+              {loading ? (
+                <div className="space-y-3">
+                  {[0, 1, 2, 4].map((i) => (
+                    <div key={i} className="flex gap-3 animate-pulse">
+                      <Skeleton className="w-8 h-11 rounded bg-white/10 shrink-0" />
+                      <div className="flex-1 space-y-1.5">
+                        <Skeleton className="h-3 w-3/4 bg-white/10" />
+                        <Skeleton className="h-3 w-1/2 bg-white/10" />
+                        <Skeleton className="h-2 w-1/4 bg-white/10" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : activity.length === 0 ? (
+                <p className="text-xs text-neutral-500">{t('home.noActivity')}</p>
+              ) : (
+                <div>
+                  {activity.map((item, i) => (
+                    <ActivityFeedItem key={i} item={item} />
+                  ))}
+                </div>
+              )}
+            </div>
+
+          </div>
+        )}
+
+        {/* Dialogs */}
         <ConfirmDialog
           open={!!confirmDelete}
           onOpenChange={(open) => !open && setConfirmDelete(null)}
@@ -418,8 +609,6 @@ export default function HomePage() {
           isLoading={deleting}
           variant="destructive"
         />
-
-        {/* Leave confirmation dialog */}
         <ConfirmDialog
           open={!!confirmLeave}
           onOpenChange={(open) => !open && setConfirmLeave(null)}

--- a/frontend/src/services/lists.ts
+++ b/frontend/src/services/lists.ts
@@ -1,5 +1,11 @@
 import { requestJson } from './api'
 
+export interface ListMemberPreviewDTO {
+  user_id: number
+  username: string
+  avatar_url?: string | null
+}
+
 export interface UserListDTO {
   id: number
   name: string
@@ -10,6 +16,47 @@ export interface UserListDTO {
   updated_at: string
   member_count: number
   movie_count: number
+  poster_urls?: string[] | null
+  members?: ListMemberPreviewDTO[] | null
+  last_activity_at?: string | null
+}
+
+export interface UserStatsDTO {
+  watched_this_month: number
+}
+
+export interface ActivityItemDTO {
+  type: 'movie_added' | 'movie_watched' | 'comment' | 'member_joined'
+  timestamp: string
+  list_id: number
+  list_name: string
+  movie_id?: number | null
+  movie_title?: string | null
+  movie_poster_url?: string | null
+  user_id?: number | null
+  username?: string | null
+  avatar_url?: string | null
+}
+
+export interface ActivityResponseDTO {
+  activity: ActivityItemDTO[]
+  count: number
+}
+
+export async function getUserStats(): Promise<UserStatsDTO> {
+  const token = localStorage.getItem('access_token')
+  return requestJson<UserStatsDTO>('/api/users/stats', {
+    method: 'GET',
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  })
+}
+
+export async function getUserActivity(limit = 20): Promise<ActivityResponseDTO> {
+  const token = localStorage.getItem('access_token')
+  return requestJson<ActivityResponseDTO>(`/api/users/activity?limit=${limit}`, {
+    method: 'GET',
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  })
 }
 
 export interface ListsResponseDTO {


### PR DESCRIPTION
## Summary

- **Poster stack** — cada card de lista exibe até 4 miniaturas de pôsteres dos filmes (TMDB `w92`)
- **Avatares de membros** — até 4 avatares empilhados por lista com fallback de iniciais
- **Última atividade** — timestamp relativo ("há 2h") baseado no max de `updated_at` e movimentações recentes de filmes
- **Stats bar** — contador de filmes assistidos no mês atual
- **Activity feed** — painel lateral (sticky no desktop) com feed em tempo real de: filme adicionado, filme assistido, comentário criado, membro entrou
- **Skeleton loading** — listas e feed mostram skeleton animado durante o carregamento inicial

## Mudanças no backend

- `GET /api/lists` enriquecido com `poster_urls`, `members` (preview) e `last_activity_at` via batch queries (sem N+1)
- `GET /api/users/stats` → `{ watched_this_month: N }`
- `GET /api/users/activity?limit=N` → UNION de `list_movies`, `comments` e `list_members` ordenado por timestamp

## Test plan

- [ ] Home carrega com skeleton e então exibe listas enriquecidas
- [ ] Listas sem filmes mostram ícone placeholder no lugar dos pôsteres
- [ ] Stat "filmes assistidos este mês" bate com o total de watched no mês
- [ ] Activity feed exibe eventos recentes para o usuário autenticado
- [ ] Layout 2 colunas no desktop, coluna única no mobile
- [ ] Skeleton do feed aparece durante carregamento

🤖 Generated with [Claude Code](https://claude.com/claude-code)