### PR TITLE
feat(home): make list cards clickable

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+    "scripts": {
+        "setup": "cp -n .env.example .env",
+        "run": "docker compose up --build",
+        "archive": "docker compose down"
+    }
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -467,7 +467,11 @@ export default function HomePage() {
                     return (
                       <li
                         key={list.id}
-                        className="group rounded-xl border border-white/10 bg-white/5 hover:border-white/20 hover:bg-white/[0.07] transition-all p-4 sm:p-5 shadow-lg shadow-black/20 hover:-translate-y-0.5"
+                        className="group rounded-xl border border-white/10 bg-white/5 hover:border-white/20 hover:bg-white/[0.07] transition-all p-4 sm:p-5 shadow-lg shadow-black/20 hover:-translate-y-0.5 cursor-pointer"
+                        onClick={(e) => {
+                          if ((e.target as HTMLElement).closest('button')) return
+                          navigate(`/list/${list.id}`)
+                        }}
                       >
                         <div className="flex items-start gap-4">
                           {/* Poster stack */}


### PR DESCRIPTION
## Summary
- List cards on the home page are now fully clickable, navigating to `/list/:id` — matching the behavior of movie cards inside a list
- Clicks on action buttons (copy code, delete, leave, open arrow) are excluded from the card-level navigation so they continue to work independently
- Added `cursor-pointer` to signal interactivity

## Test plan
- [ ] Click anywhere on a list card body → navigates to the list page
- [ ] Click the copy-code button → copies code, no navigation
- [ ] Click the delete/leave/arrow buttons → expected action, no double-navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)